### PR TITLE
patch for Plack::Middleware::AccessLog

### DIFF
--- a/lib/Plack/Middleware/AccessLog.pm
+++ b/lib/Plack/Middleware/AccessLog.pm
@@ -46,7 +46,8 @@ sub log_line {
         my($block, $type) = @_;
         if ($type eq 'i') {
             $block =~ s/-/_/;
-            return _safe($env->{"HTTP_" . uc($block)}) || "-";
+            my $val = _safe($env->{"HTTP_" . uc($block)});
+            return defined $val ? $val : "-";
         } elsif ($type eq 'o') {
             return scalar $h->get($block) || "-";
         } elsif ($type eq 't') {

--- a/t/Plack-Middleware/access_log_value_zero.t
+++ b/t/Plack-Middleware/access_log_value_zero.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+use Test::More;
+use HTTP::Request::Common;
+use Plack::Test;
+use Plack::Builder;
+use POSIX;
+
+my $log;
+
+my $test = sub {
+    my $format = shift;
+    return sub {
+        my $req = shift;
+        my $app = builder {
+            enable "Plack::Middleware::AccessLog",
+                logger => sub { $log = "@_" }, format => $format;
+            sub { [ 200, [ 'Content-Type' => 'text/plain' ], [ 'OK' ] ] };
+        };
+        test_psgi $app, sub { $_[0]->($req) };
+    };
+};
+
+{
+    my $req = GET "http://example.com/";
+    $req->header("Zero" => "0");
+
+    my $fmt = "%{zero}i %{undef}i";
+    $test->($fmt)->($req);
+    chomp $log;
+    is $log, "0 -";
+}
+
+{
+    $test->("%D")->(GET "/");
+    chomp $log;
+    is $log, '-';
+}
+
+done_testing;


### PR DESCRIPTION
I found Plack::Middleware::AccessLog publishes '-' when $env{HTTP_FOO} == '0'.

I want to write '0' to my log file. How about this patch ?
