### PR TITLE
Psgix.trace

### DIFF
--- a/lib/Plack/Middleware/StackTrace.pm
+++ b/lib/Plack/Middleware/StackTrace.pm
@@ -28,7 +28,7 @@ sub call {
 
     if ($trace && ($caught || ($self->force && ref $res eq 'ARRAY' && $res->[0] == 500)) ) {
         my $text = trace_as_string($trace);
-        $env->{'psgix.trace'} = $text;
+        $env->{'plack.stacktrace'} = $text;
         $env->{'psgi.errors'}->print($text) unless $self->no_print_errors;
         if (($env->{HTTP_ACCEPT} || '*/*') =~ /html/) {
             $res = [500, ['Content-Type' => 'text/html; charset=utf-8'], [ utf8_safe($trace->as_html) ]];
@@ -92,7 +92,7 @@ Plack::Middleware::StackTrace - Displays stack trace when your app dies
 
 This middleware catches exceptions (run-time errors) happening in your
 application and displays nice stack trace screen. The stack trace is
-also stored in the environment under the key C<psgix.trace> so that
+also stored in the environment under the key C<plack.stacktrace> so that
 middleware futher up the stack can reference it.
 
 This middleware is enabled by default when you run L<plackup> in the

--- a/t/Plack-Middleware/stacktrace.t
+++ b/t/Plack-Middleware/stacktrace.t
@@ -9,7 +9,7 @@ my $traceapp = Plack::Middleware::StackTrace->wrap(sub { die "orz" }, no_print_e
 my $app = sub {
     my $env = shift;
     my $ret = $traceapp->($env);
-    like $env->{'psgix.trace'}, qr/orz/;
+    like $env->{'plack.stacktrace'}, qr/orz/;
     return $ret;
 };
 


### PR DESCRIPTION
I'd like to be able to reference the stack trace created by the StackTrace middleware further up the stack. This will allow my ErrorDocument subrequest to grab it and send it in an email. Seems like a natural extension of the StackTrace middleware and it'd be silly to write a separate middleware for this.

Thanks,

Theory
