### PR TITLE
WrapCGI pipe issue

### DIFF
--- a/t/Plack-Middleware/wrapcgi.t
+++ b/t/Plack-Middleware/wrapcgi.t
@@ -49,5 +49,27 @@ print \$q->header, "Hello ", \$q->param('name'), " counter=", ++\$COUNTER;
     undef $tmp;
 };
 
+{
+    my $tmp = File::Temp->new(CLEANUP => 1);
+    print $tmp <<"...";
+#!$^X
+use CGI;
+my \$q = CGI->new;
+print \$q->header, "Hello " x 10000;
+...
+    close $tmp;
+
+    chmod(oct("0700"), $tmp->filename) or die "Cannot chmod";
+
+    my $app_exec = Plack::App::WrapCGI->new(script => "$tmp", execute => 1)->to_app;
+    test_psgi app => $app_exec, client => sub {
+        my $cb = shift;
+
+        my $res = $cb->(GET "http://localhost/");
+        is $res->code, 200;
+    };
+
+    undef $tmp;
+};
 
 done_testing;


### PR DESCRIPTION
WrapCGI で execute => 1 している場合に、CGI が pipe の容量以上の書き込みをしようとするとブロックしてしまう現象の修正です。

waitpidのperldoc引くと

Non‐blocking wait is available on machines supporting either the waitpid(2) or wait4(2) syscalls.

とあるので、この修正はポータビリティ的には微妙かもしれません。
が、とりあえず問題は解決します。
