### PR TITLE
fixed AccessLog to handle multiple dashes in %{...}i

### DIFF
--- a/lib/Plack/Middleware/AccessLog.pm
+++ b/lib/Plack/Middleware/AccessLog.pm
@@ -45,7 +45,7 @@ sub log_line {
     my $block_handler = sub {
         my($block, $type) = @_;
         if ($type eq 'i') {
-            $block =~ s/-/_/;
+            $block =~ s/-/_/g;
             my $val = _safe($env->{"HTTP_" . uc($block)});
             return defined $val ? $val : "-";
         } elsif ($type eq 'o') {

--- a/t/Plack-Middleware/access_log.t
+++ b/t/Plack-Middleware/access_log.t
@@ -23,13 +23,13 @@ my $test = sub {
 
 {
     my $req = GET "http://example.com/";
-    $req->header("Host" => "example.com");
+    $req->header("Host" => "example.com", "X-Forwarded-For" => "192.0.2.1");
 
-    my $fmt = "%{Host}i %{Content-Type}o %{%m %y}t";
+    my $fmt = "%{Host}i %{X-Forwarded-For}i %{Content-Type}o %{%m %y}t";
     $test->($fmt)->($req);
     chomp $log;
     my $month_year = POSIX::strftime('%m %y', localtime);
-    is $log, "example.com text/plain [$month_year]";
+    is $log, "example.com 192.0.2.1 text/plain [$month_year]";
 }
 
 {


### PR DESCRIPTION
Middleware::AccessLog で %{X-Forwarded-For}i とかできなかったので直しました。
問題なければ pull お願いします。
