### PR TITLE
Rewrote a patch of handling Authorization header.

### DIFF
--- a/lib/Plack/Handler/Apache1.pm
+++ b/lib/Plack/Handler/Apache1.pm
@@ -50,6 +50,10 @@ sub call_app {
         'psgi.nonblocking'    => Plack::Util::FALSE,
     };
 
+    if (defined(my $HTTP_AUTHORIZATION = $r->headers_in->{Authorization})) {
+        $env->{HTTP_AUTHORIZATION} = $HTTP_AUTHORIZATION;
+    }
+
     my $vpath    = $env->{SCRIPT_NAME} . $env->{PATH_INFO};
 
     my $location = $r->location || "/";

--- a/lib/Plack/Handler/Apache2.pm
+++ b/lib/Plack/Handler/Apache2.pm
@@ -49,6 +49,10 @@ sub call_app {
         'psgi.nonblocking'    => Plack::Util::FALSE,
     };
 
+    if (defined(my $HTTP_AUTHORIZATION = $r->headers_in->{Authorization})) {
+        $env->{HTTP_AUTHORIZATION} = $HTTP_AUTHORIZATION;
+    }
+
     $class->fixup_path($r, $env);
 
     my $res = $app->($env);

--- a/t/Plack-Handler/cgi.t
+++ b/t/Plack-Handler/cgi.t
@@ -13,6 +13,7 @@ use Plack::Test::Suite;
 
 Plack::Test::Suite->runtests(sub {
     my ($name, $test, $handler) = @_;
+    local $ENV{PLACK_TEST_HANDLER} = 'CGI';
 
     note $name;
     my $cb = sub {
@@ -21,6 +22,9 @@ Plack::Test::Suite->runtests(sub {
         my $cgi = HTTP::Request::AsCGI->new($req);
         my $c = $cgi->setup;
         $ENV{SCRIPT_NAME} = '/plack_test.cgi';
+        # Apache's CGI implementation does not pass "Authorization" header by untrusted ENV.
+        # We bow down to it under this test.
+        delete $ENV{HTTP_AUTHORIZATION};
         eval { Plack::Handler::CGI->new->run($handler) };
         my $res = $c->response;
         $res->request($req);


### PR DESCRIPTION
Some problems are fixed but some problems came out.
- With previous patch, current t/Plack-Handler/cgi.t is passed because it uses HTTP::Request::AsCGI which does not drop Authorization header. (Actually, lighttpd's mod_cgi does not drop it)
- All FCGI tests are passed... There may be missing Authorization problem only under Apache's mod_fcgi (lighttpd passes Authorization header correctly)

I was stuck with what to do but I rewrote this patch as following:
- t/Plack-Handler/cgi.t: Drop Authorization header like Apache. (but I entertain doubts about this) And, set PLACK_TEST_HANDLER=CGI
- lib/Plack/Test/Suite.pm: Check PLACK_TEST_HANDLER and skip the test.

Rewrote handler as you say:
lib/Plack/Handler/Apache[12].pm
