### PR TITLE
change to header_get

### DIFF
--- a/lib/Plack/Util.pm
+++ b/lib/Plack/Util.pm
@@ -193,7 +193,9 @@ sub header_get {
         push @val, $_[1] if lc $_[0] eq $key;
     };
 
-    return wantarray ? @val : $val[0];
+    my $val  = join(', ', @val);
+
+    return wantarray ? ($val) : $val;
 }
 
 sub header_set {

--- a/t/Plack-Util/headers.t
+++ b/t/Plack-Util/headers.t
@@ -33,6 +33,12 @@ use Plack::Util;
 {
     my $headers = [ Foo => 'bar', Bar => 'baz' ];
     Plack::Util::header_push($headers, Foo => 'quox');
+    is Plack::Util::header_get($headers, 'foo'), 'bar, quox', 'merged values for header_get()';
+}
+
+{
+    my $headers = [ Foo => 'bar', Bar => 'baz' ];
+    Plack::Util::header_push($headers, Foo => 'quox');
     is_deeply $headers, [ Foo => 'bar', Bar => 'baz', Foo => 'quox' ];
 }
 

--- a/t/Plack-Util/headers_obj.t
+++ b/t/Plack-Util/headers_obj.t
@@ -13,9 +13,9 @@ use Plack::Util;
 
     is $h->get('Foo'), 'bar';
     $h->push('Foo' => 'xxx');
-    is $h->get('Foo'), 'bar';
+    is $h->get('Foo'), 'bar, xxx';
     my @v = $h->get('Foo');
-    is_deeply \@v, [ 'bar', 'xxx' ];
+    is_deeply \@v, [ 'bar, xxx' ];
 
     ok $h->exists('Bar');
     $h->remove('Bar');


### PR DESCRIPTION
Plack::MW::Deflater assumes there will only ever be one Cache-Control header, this
took us a while to debug as we set multiple Cache-Control headers...

$h->get('Cache-Control') =~ /\bno-transform\b/; # not working as our first Cache-Control was something else

We were then caught out by a similar bug when implementing something ourselves!

So this patch makes header_get() join the values of all identical headers and return them. Users should already
expect multiple values in a header (because they can be set that way) so hopefully this should not have any knock on effects. I maintained list context just for backwards compat.
