### PR TITLE
ConditionalGET with streaming response

### DIFF
--- a/t/Plack-Middleware/conditionalget_writer.t
+++ b/t/Plack-Middleware/conditionalget_writer.t
@@ -1,0 +1,53 @@
+use strict;
+use warnings;
+use Test::More;
+use Plack::Builder;
+use HTTP::Request::Common;
+use Plack::Test;
+
+my $handler = builder {
+    
+    enable 'ConditionalGET';
+
+    sub {
+        my $env = shift;
+        
+        return sub {
+            my $writer = shift->( [ 200, [
+                'Content-Type' => 'text/plain',
+                'ETag' => 'DEADBEEF',
+            ] ] );
+            
+            $writer->write($_) for ( qw( kling klang klong ) );
+            $writer->close;
+        };
+
+    };
+};
+
+test_psgi $handler, sub {
+    my $cb = shift;
+
+    subtest 'streaming' => sub {
+
+        my $res = $cb->( GET "http://localhost/streaming-klingklangklong" );
+        is $res->code, 200, 'Response HTTP status';
+        is $res->content, 'klingklangklong', 'Response content';
+
+    };
+    
+    subtest 'streaming not modified' => sub {
+
+        my $res = $cb->( GET
+            "http://localhost/streaming-klingklangklong",
+            'If-None-Match' => 'DEADBEEF'
+        );
+        is $res->code, 304, 'Response HTTP status';
+        is $res->content, '', 'Response content';
+
+    };
+    
+};
+
+done_testing;
+


### PR DESCRIPTION
ConditionalGET doesn't work with streaming response. The error is 

```
Can't call method "write" on an undefined value [...]
```

I think happens because body is "pruned" from the response, while the streaming backend tries to push data. Here is a failing test for that case.
