### PR TITLE
Improved Plack::Test::Suite 'validate env' to test for SCRIPT_NAME.

### DIFF
--- a/lib/Plack/Test/Suite.pm
+++ b/lib/Plack/Test/Suite.pm
@@ -247,6 +247,7 @@ our @TEST = (
             is $res->header('content_type'), 'text/plain';
             is $res->content, join("\n",
                 'REQUEST_METHOD:GET',
+                "SCRIPT_NAME:$ENV{PLACK_TEST_SCRIPT_NAME}",
                 'PATH_INFO:/foo/',
                 'QUERY_STRING:dankogai=kogaidan',
                 'SERVER_NAME:127.0.0.1',
@@ -256,7 +257,7 @@ our @TEST = (
         sub {
             my $env = shift;
             my $body;
-            $body .= $_ . ':' . $env->{$_} . "\n" for qw/REQUEST_METHOD PATH_INFO QUERY_STRING SERVER_NAME SERVER_PORT/;
+            $body .= $_ . ':' . $env->{$_} . "\n" for qw/REQUEST_METHOD SCRIPT_NAME PATH_INFO QUERY_STRING SERVER_NAME SERVER_PORT/;
             return [
                 200,
                 [ 'Content-Type' => 'text/plain', ],
@@ -769,9 +770,7 @@ sub run_server_tests {
                 my $cb = sub {
                     my $req = shift;
                     $req->uri->port($http_port || $port);
-                    if ($ENV{PLACK_TEST_SCRIPT_NAME}) {
-                        $req->uri->path($ENV{PLACK_TEST_SCRIPT_NAME} . $req->uri->path);
-                    }
+                    $req->uri->path(($ENV{PLACK_TEST_SCRIPT_NAME}||"") . $req->uri->path);
                     $req->header('X-Plack-Test' => $i);
                     return $ua->request($req);
                 };


### PR DESCRIPTION
In http://search.cpan.org/~miyagawa/PSGI-1.03/PSGI.pod, "The
Environment":

```
SERVER_NAME, SERVER_PORT: When combined with SCRIPT_NAME and
PATH_INFO, these variables can be used to complete the URL. Note,
however, that HTTP_HOST, if present, should be used in preference to
SERVER_NAME for reconstructing the request URL. SERVER_NAME and
SERVER_PORT can never be empty strings, and so are always required.
```

The 'validate env' test tested SERVER_NAME, SERVER_PORT & PATH_INFO, but
not PATH_INFO.

ps.  There also is one minor code improvement.
