### PR TITLE
Remove false dependency on LWP.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,9 @@ name 'Plack';
 all_from 'lib/Plack.pm';
 readme_from 'lib/Plack.pm';
 
-requires 'LWP', 5.814;                      # HTTP::Status, HTTP::Headers and HTTP::Request
+requires 'HTTP::Status', 5.814;
+requires 'HTTP::Headers', 5.814;
+requires 'HTTP::Request', 5.814;
 requires 'URI', 1.36;                       # URI::Escape
 requires 'Pod::Usage';                      # plackup
 requires 'File::ShareDir', '1.00';          # Plack::Test::Suite


### PR DESCRIPTION
```
All the modules named in comments have been moved to the HTTP-Message distribution
This helps to eliminate an indirect XS dependency, due to HTML::Parser in the LWP distribution

The Module::Install docs confirm that specifying a module rather
than a dependency is a best practice:

"Note that the dependency is on a module and not a distribution.
This is to ensure that your dependency stays correct, even if the
module is moved or merged into a different distribution, as is
occasionally the case."
```

Thanks!

```
Mark
```
