### PR TITLE
Allow SCRIPT_NAME to be missing in CGI handler

### DIFF
--- a/lib/Plack/Handler/CGI.pm
+++ b/lib/Plack/Handler/CGI.pm
@@ -103,10 +103,9 @@ sub setup_env {
     delete $env->{HTTP_CONTENT_LENGTH};
     $env->{'HTTP_COOKIE'} ||= $ENV{COOKIE}; # O'Reilly server bug
 
-    if (!exists $env->{PATH_INFO}) {
-        $env->{PATH_INFO} = '';
-    }
-
+    $env->{PATH_INFO}   = '' if !exists $env->{PATH_INFO};
+    $env->{SCRIPT_NAME} = '' if !exists $env->{SCRIPT_NAME};
+    
     if ($env->{SCRIPT_NAME} eq '/') {
         $env->{SCRIPT_NAME} = '';
         $env->{PATH_INFO}   = '/' . $env->{PATH_INFO};


### PR DESCRIPTION
```
This is correct according to the CGI 1.1 spec at: http://www.ietf.org/rfc/rfc3875
section 4.1.13, which reads in part:
"[SCRIPT_NAME] is optional if the path is NULL; however, the variable MUST
still be set in that case."

As a practical issue, it can help with a first-impression of Plack, when
a basic "Hello World" test is run from the command-line, which wouldn't
set SCRIPT_NAME in the environment, resulting in a warning like this:

Use of uninitialized value in string eq at /usr/local/share/perl/5.10.1/Plack/Handler/CGI.pm line 110.
Status: 200 OK
Content-Type: text/html; charset=ISO-8859-1

Hello World
```
#### 

Thanks!

```
  Mark
```
