### PR TITLE
HTTPExceptions fixes

### DIFF
--- a/lib/Plack/Middleware/HTTPExceptions.pm
+++ b/lib/Plack/Middleware/HTTPExceptions.pm
@@ -107,18 +107,19 @@ Plack::Middleware::HTTPExceptions - Catch HTTP exceptions
 =head1 DESCRIPTION
 
 Plack::Middleware::HTTPExceptions is a PSGI middleware component to
-catch exceptions from applicaitions that can be translated into HTTP
-status code.
+catch exceptions from applications that can be translated into HTTP
+status codes.
 
-Your application is supposed to throw an object that implements
-C<code> method which returns the HTTP status code such as 501 or
+Your application is supposed to throw an object that implements a
+C<code> method which returns the HTTP status code, such as 501 or
 404. This middleware catches them and creates a valid response out of
 the code. If the C<code> method returns a code that is not an HTTP
-redirect or error code (3xx, 4xx, or 5xx), the exception will be rethrown.
+redirect or error code (3xx, 4xx, or 5xx), the exception will be
+rethrown.
 
-The exception object may also implement C<as_string>, or overload the
-stringification, to represent the text of the error, which defaults to
-the status message of error codes, such as I<Service Unavailable> for
+The exception object may also implement C<as_string> or overload
+stringification to represent the text of the error. The text defaults to
+the status message of the error code, such as I<Service Unavailable> for
 C<503>.
 
 Finally, the exception object may implement C<as_psgi>, and the result
@@ -129,7 +130,7 @@ method (HTTP::Exception::3xx does), the Location header will be set in the
 response, so you can do redirects this way.
 
 There are CPAN modules L<HTTP::Exception> and L<HTTP::Throwable>, and
-they are pefect to throw from your application to let this middleware
+they are perfect to throw from your application to let this middleware
 catch and display, but you can also implement your own exception class
 to throw.
 


### PR DESCRIPTION
this allows HTTPExceptions to optionally rethrow exceptions so that other middleware can catch them, as well as providing support for HTTP::Throwable exceptions (really, anything with an as_psgi method). I'll leave it up to you whether or not to pull in the second commit here(:
