### PR TITLE
a fix against HTTP header injection

### DIFF
--- a/lib/Plack/Response.pm
+++ b/lib/Plack/Response.pm
@@ -9,6 +9,7 @@ use Carp ();
 use Scalar::Util ();
 use HTTP::Headers;
 use URI::Escape ();
+use URI ();
 
 sub code    { shift->status(@_) }
 sub content { shift->body(@_)   }
@@ -65,7 +66,15 @@ sub content_encoding {
 }
 
 sub location {
-    shift->headers->header('Location' => @_);
+    my $self = shift;
+
+    if (@_) {
+        my $uri = shift;
+        my $loc = URI->new($uri)->as_string;
+        $self->headers->header('Location' => $loc);
+    }
+
+    return $self->headers->header('Location');
 }
 
 sub redirect {

--- a/t/Plack-Response/redirect.t
+++ b/t/Plack-Response/redirect.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use Plack::Response;
+use URI;
 
 {
     my $res = Plack::Response->new;
@@ -16,6 +17,15 @@ use Plack::Response;
     my $res = Plack::Response->new;
     $res->redirect('http://www.google.com/', 301);
     is_deeply $res->finalize, [ 301, [ 'Location' => 'http://www.google.com/' ], [] ];
+}
+
+{
+    my $uri_invalid = "http://www.google.com/\r\nX-Injection: true\r\n\r\nHello World";
+    my $uri_valid   = URI->new($uri_invalid)->as_string;
+
+    my $res = Plack::Response->new;
+    $res->redirect($uri_invalid, 301);
+    is_deeply $res->finalize, [ 301, [ 'Location' => $uri_valid ], [] ];
 }
 
 done_testing;


### PR DESCRIPTION
`Plack::Response::location()` allows `\r\n`, so this method can easily produce HTTP header injection.

Reproducible code: https://gist.github.com/d9d0e4dfca7f38bba4bf
