### PR TITLE
Use a plain L<> for older POD processors.

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -362,8 +362,8 @@ certainly possible but not recommended: it's like doing so with
 mod_perl's Apache::Request: yet too low level.
 
 If you're writing a web application, not a framework, then you're
-encouraged to use one of the L<web application frameworks|http://plackperl.org/#frameworks> that support
-PSGI, or see modules like L<HTTP::Engine> to provide higher level
+encouraged to use one of the web application frameworks that support PSGI (L<http://plackperl.org/#frameworks>),
+or see modules like L<HTTP::Engine> to provide higher level
 Request and Response API on top of PSGI.
 
 =head1 METHODS


### PR DESCRIPTION
Looks like older pod2html didn't like URIs with labels -- cannot resolve L<web application frameworks|http://plackperl.org/#frameworks> in paragraph 89.

Sorry for the double-requesting & thanks for your time. :-)
