### PR TITLE
Plack::Handler::CGI->new->run($app) don't set SCRIPT_NAME.

### DIFF
--- a/lib/Plack/Handler/CGI.pm
+++ b/lib/Plack/Handler/CGI.pm
@@ -110,7 +110,7 @@ sub setup_env {
         $env->{PATH_INFO} = '';
     }
 
-    if ($env->{SCRIPT_NAME} eq '/') {
+    if (!exists $env->{SCRIPT_NAME} || $env->{SCRIPT_NAME} eq '/') {
         $env->{SCRIPT_NAME} = '';
         $env->{PATH_INFO}   = '/' . $env->{PATH_INFO};
     }


### PR DESCRIPTION
I wrote an Amon2::Lite app. And run as cgi script like following.

```
Plack::Handler::CGI->new->run(__PACKAGE__->to_app);
```

But P::H::C->new->run($app) don't set SCRIPT_NAME. Then return always 404.

description in japanese: http://mattn.kaoriya.net/software/lang/perl/20110720190552.htm
