### PR TITLE
Close wrapped cgi's STDIN so the process won't hang

### DIFF
--- a/lib/Plack/App/WrapCGI.pm
+++ b/lib/Plack/App/WrapCGI.pm
@@ -54,6 +54,8 @@ sub prepare_app {
                 my $fh = $env->{'psgi.input'};
                 <$fh>;
             });
+            # close STDIN so child will stop waiting
+            close $stdinw;
 
             my $res = '';
             while (waitpid($pid, WNOHANG) <= 0) {


### PR DESCRIPTION
Found child process of executed WrapCGI hanging waiting for more STDIN.
Explicitly closing the handle after writing seems to resolve this.
