### PR TITLE
add run_after_request() and guard() to Plack::Util

### DIFF
--- a/t/Plack-Util/run_after_request.t
+++ b/t/Plack-Util/run_after_request.t
@@ -1,0 +1,23 @@
+use Test::More;
+use Plack::Util;
+use strict;
+
+my $x = 0;
+{
+    my $guard = Plack::Util::guard { $x++ };
+    is($x, 0, 'guard has not fired yet');
+}
+is($x, 1, 'guard has fired');
+
+my %x;
+{
+    my $env = {};
+    {
+        Plack::Util::run_after_request($env, sub { $x{a} = 1 });
+        Plack::Util::run_after_request($env, sub { $x{b} = 2 });
+    }
+    is_deeply(\%x, {}, 'guards have not fired yet');
+}
+is_deeply(\%x, { a => 1, b => 2 }, 'multiple guards fired');
+
+done_testing;


### PR DESCRIPTION
per conversion on #plack this makes more sense than implementing it as a middleware.  what do you think? should I release a standalone PlackX::RunAfterRequest or Plack::Util::RunAfterRequest first?
