### PR TITLE
Change IPv6 default listen addr from loopback to wildcard

### DIFF
--- a/lib/HTTP/Server/PSGI.pm
+++ b/lib/HTTP/Server/PSGI.pm
@@ -78,8 +78,8 @@ sub prepare_socket_class {
     } elsif ($self->{ipv6}) {
         eval { require IO::Socket::IP; 1 }
             or Carp::croak("IPv6 support requires IO::Socket::IP");
-        $self->{host}      ||= '::1';
-        $args->{LocalAddr} ||= '::1';
+        $self->{host}      ||= '::';
+        $args->{LocalAddr} ||= '::';
         return "IO::Socket::IP";
     }
 


### PR DESCRIPTION
As mentioned on IRC, when enabling IPv6 support the default listen address is updated but to the loopback address (::1) instead of the wildcard address (::).

This small patch sets the default listen address for IPv6 to be the wildcard address.
