### PR TITLE
Fix Plack::Middleware::AccessLog logger configuration example

### DIFF
--- a/lib/Plack/Middleware/AccessLog.pm
+++ b/lib/Plack/Middleware/AccessLog.pm
@@ -161,7 +161,7 @@ Apache's LogFormat templates.
 
   my $logger = Log::Dispatch->new(...);
   enable "Plack::Middleware::AccessLog",
-      logger => sub { $logger->log(debug => @_) };
+      logger => sub { $logger->log(level => 'debug', message => @_) };
 
 Sets a callback to print log message to. It prints to C<psgi.errors>
 output stream by default.


### PR DESCRIPTION
The current example says something like this:

``` perl

enable 'AccessLog', logger => sub { $logger->log(debug => @_) };

```

This usage doesn't work with current Log::Dispatch; so I updated it to this:

``` perl

enable 'AccessLog', logger => sub { $logger->log(level => 'debug', message => @_) };

```
