### PR TITLE
Add stream_chunked middleware parameter

### DIFF
--- a/lib/Plack/Middleware/BufferedStreaming.pm
+++ b/lib/Plack/Middleware/BufferedStreaming.pm
@@ -37,6 +37,7 @@ sub call {
                     close => sub {
                         if ($ret) {
                             $ret->([ @$write, \@body ]);
+                            undef $ret;
                         }
                         else {
                             $ret = [ @$write, \@body ];


### PR DESCRIPTION
This option allows transformation of chunked streaming responses into unchunked streaming responses by buffering calls to $writer->write. Only works with servers that support streamed responses.

The motivation of this is to allow Deflater to work with the chunked responses generated by Plack::App::Proxy::Backend::AnyEvent::HTTP under Twiggy.
