### PR TITLE
Fixes a problem with the streaming interface and an empty body

### DIFF
--- a/lib/HTTP/Message/PSGI.pm
+++ b/lib/HTTP/Message/PSGI.pm
@@ -134,8 +134,9 @@ sub _res_from_psgi {
     };
 
     if (!defined $body) {
+        $body = [];
         my $o = Plack::Util::inline_object
-            write => sub { push @{ $body ||= [] }, @_ },
+            write => sub { push @$body, @_ },
             close => $convert_resp;
 
         return $o;


### PR DESCRIPTION
Hello,

take this patch with a graint of salt, as i have never worked with the streaming interface. But if a streamed response has no body, like in response to a HEAD request, $body is still undefined when HTTP::Message::PSGI tries to use it as array reference or IO::Handle object. Hope this helps.

Best wishes, Mario
