### PR TITLE
fix restart on windows

### DIFF
--- a/lib/Plack/Loader/Restarter.pm
+++ b/lib/Plack/Loader/Restarter.pm
@@ -42,11 +42,10 @@ sub _kill_child {
     my $pid = $self->{pid} or return;
     warn "Killing the existing server (pid:$pid)\n";
     kill 'TERM' => $pid;
-    my $kid;
     # NOTE: win32: don't use waitpid($pid, 0). need loop to die for widnows.
     do {
         $pid = waitpid(-1, WNOHANG);
-    } while defined($kid) && $kid > 0;
+    } while defined($pid) && $pid > 0;
 }
 
 sub valid_file {


### PR DESCRIPTION
It need loop to die for windows. waitpid() don't notify TERM to child process(fork emulation).
