### PR TITLE
STD{IN,OUT, ERR} handles in Plack::Handler::FCGI

### DIFF
--- a/lib/Plack/Handler/FCGI.pm
+++ b/lib/Plack/Handler/FCGI.pm
@@ -161,8 +161,8 @@ sub run {
 sub _handle_response {
     my ($self, $res) = @_;
 
-    *STDOUT->autoflush(1);
-    binmode STDOUT;
+    $self->{stdout}->autoflush(1);
+    binmode $self->{stdout};
 
     my $hdrs;
     my $message = status_message($res->[0]);


### PR DESCRIPTION
Provide I/O handles to FCGI::Request() instead of relying on global STD{IN,OUT, ERR}, this to prevent clashes with IPC software such as Capture::Tiny.
