### PR TITLE
Proper support for callback-style streaming body in AccessLog::Timed

### DIFF
--- a/lib/Plack/Middleware/AccessLog/Timed.pm
+++ b/lib/Plack/Middleware/AccessLog/Timed.pm
@@ -21,8 +21,20 @@ sub call {
         my($status, $header, $body) = @$res;
 
         if (!defined $body) {
-            $logger->( $self->log_line($status, $header, $env) );
-            return;
+            my $length;
+
+            return sub {
+                my $line = shift;
+                
+                $length += length $line if defined $line;
+
+                unless( defined $line ) {
+                    my $now = Time::HiRes::gettimeofday;
+                    $logger->( $self->log_line($status, $header, $env, { time => $now - $time, content_length => $length }) );
+                }
+
+                return $line;
+            };
         }
 
         my $getline = ref $body eq 'ARRAY' ? sub { shift @$body } : sub { $body->getline };

--- a/t/Plack-Middleware/access_log_timed.t
+++ b/t/Plack-Middleware/access_log_timed.t
@@ -38,4 +38,88 @@ my $test_req = sub {
     like $log, qr@GET /foo%20bar\?baz=baz HTTP/1\.1@;
 }
 
+# Testing delayed responses
+
+$log = "";
+$handler = builder {
+    enable "Plack::Middleware::AccessLog::Timed",
+        logger => sub { $log .= "@_" };
+    sub { 
+        return sub { 
+            $_[0]->( [ 200, [ 'Content-Type' => 'text/plain' ], [ 'OK' ] ] ) 
+        } 
+    };
+};
+
+$test_req = sub {
+    my $req = shift;
+    test_psgi app => $handler,
+        client => sub {
+        my $cb = shift;
+        $cb->($req);
+    };
+};
+
+{
+    $test_req->(GET "http://localhost/");
+    like $log, qr@^127\.0\.0\.1 - - \[.*?\] "GET / HTTP/1\.1" 200 2@;
+}
+
+{
+    $log = "";
+    $test_req->(POST "http://localhost/foo", { foo => "bar" });
+    like $log, qr@^127\.0\.0\.1 - - \[.*?\] "POST /foo HTTP/1\.1" 200 2@;
+}
+
+{
+    $log = "";
+    $test_req->(GET "http://localhost/foo%20bar?baz=baz");
+    like $log, qr@GET /foo%20bar\?baz=baz HTTP/1\.1@;
+}
+
+
+
+# Testing streaming responses
+
+$log = "";
+$handler = builder {
+    enable "Plack::Middleware::AccessLog::Timed",
+        logger => sub { $log .= "@_" };
+    
+    sub { 
+        return sub { 
+            my $writer = $_[0]->( [ 200, [ 'Content-Type' => 'text/plain' ] ] );
+            $writer->write("OK");
+            $writer->close;
+        } 
+    };
+};
+
+$test_req = sub {
+    my $req = shift;
+    test_psgi app => $handler,
+        client => sub {
+        my $cb = shift;
+        $cb->($req);
+    };
+};
+
+{
+    $test_req->(GET "http://localhost/");
+    like $log, qr@^127\.0\.0\.1 - - \[.*?\] "GET / HTTP/1\.1" 200 2@;
+}
+
+{
+    $log = "";
+    $test_req->(POST "http://localhost/foo", { foo => "bar" });
+    like $log, qr@^127\.0\.0\.1 - - \[.*?\] "POST /foo HTTP/1\.1" 200 2@;
+}
+
+{
+    $log = "";
+    $test_req->(GET "http://localhost/foo%20bar?baz=baz");
+    like $log, qr@GET /foo%20bar\?baz=baz HTTP/1\.1@;
+}
+
+
 done_testing;


### PR DESCRIPTION
Plack::Middleware::AccessLog::Timed claims to log at the end of processing the request. But applications using the callback styled streaming body interface the request is logged at the start of the streaming when the writer callback is generated.

This means that neither the length nor the the time is correctly logged.

This patch seems to fix that (according to the added test cases)
