### PR TITLE
Remove utf8::downgrade step for URI in HTTP::Message::PSGI

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,7 @@ readme_from 'lib/Plack.pm';
 
 requires 'LWP::UserAgent', 5.814;           # Plack::Test
 requires 'HTTP::Message', 5.814;
-requires 'URI', 1.36;
+requires 'URI', 1.59;
 requires 'Pod::Usage', 1.36;                # plackup
 requires 'File::ShareDir', '1.00';          # Plack::Test::Suite
 requires 'Try::Tiny';

--- a/lib/HTTP/Message/PSGI.pm
+++ b/lib/HTTP/Message/PSGI.pm
@@ -28,12 +28,6 @@ sub req_to_psgi {
     $uri->port(80)          unless $uri->port;
     $uri->host_port($host)  unless !$host || ( $host eq $uri->host_port );
 
-    # STUPID: If the request URI is utf-8 decoded, methods like ->path
-    # and ->host returns decoded strings in ascii, which causes double
-    # encoded strings in uri_unescape and URI concatenation in
-    # Plack::Request :/
-    utf8::downgrade $$uri;
-
     my $input;
     my $content = $req->content;
     if (ref $content eq 'CODE') {


### PR DESCRIPTION
Not necessary anymore as per fix in URI.pm at 1.59 version.
