### PR TITLE
Path escaping regex supports RFC 3986 definition.

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -185,8 +185,9 @@ sub uri {
     # This means when a request like /foo%2fbar comes in, we recognize
     # it as /foo/bar which is not ideal, but that's how the PSGI PATH_INFO
     # spec goes and we can't do anything about it. See PSGI::FAQ for details.
-    # http://github.com/plack/Plack/issues#issue/118
-    my $path_escape_class = '^A-Za-z0-9\-\._~/';
+
+    # See RFC 3986 before modifying.
+    my $path_escape_class = q{^/;:@&=A-Za-z0-9$_.+!*'(),-};
 
     my $path = URI::Escape::uri_escape($self->env->{PATH_INFO} || '', $path_escape_class);
     $path .= '?' . $self->env->{QUERY_STRING}

--- a/t/Plack-Request/uri.t
+++ b/t/Plack-Request/uri.t
@@ -43,6 +43,13 @@ my @tests = (
       },
       uri => 'http://example.com/exec/',
       parameters => {} },
+
+    { add_env => {
+        HTTP_HOST => 'example.com',
+        SCRIPT_NAME => '/exec/'
+      },
+      uri => 'http://example.com/exec/',
+      parameters => {} },
     { add_env => {
         SERVER_NAME => 'example.com'
       },
@@ -85,7 +92,15 @@ my @tests = (
         PATH_INFO => "/baz quux",
       },
       uri => 'http://example.com/foo%20bar/baz%20quux',
-      parameters => {} }
+      parameters => {} },
+    { add_env => {
+        HTTP_HOST => 'example.com',
+        SCRIPT_NAME => "/path",
+        PATH_INFO => "/parameters;path=one,two",
+        QUERY_STRING => "query=foobar",
+      },
+      uri => 'http://example.com/path/parameters;path=one,two?query=foobar',
+      parameters => { query => "foobar" } },
 );
 
 plan tests => 2 * @tests;


### PR DESCRIPTION
- Updated the class of characters-to-not-escape passed to URI::Escape to
  support the proper definition as stipulated by RFC 3986 for URL Paths,
  namely::
  
  safe           = "$" | "-" | "_" | "." | "+"
  extra          = "!" | "*" | "'" | "(" | ")" | ","
  
  unreserved     = alpha | digit | safe | extra
  escape         = "%" hex hex
  
  uchar          = unreserved | escape
  
  hpath          = hsegment *[ "/" hsegment ]
  hsegment       = *[ uchar | ";" | ":" | "@" | "&" | "=" ]
  - Added unit test which verifies behavior by attempting to use path
    parameters.
