### PR TITLE
make "Basic" detection insensitive as per RFC2617

### DIFF
--- a/lib/Plack/Middleware/Auth/Basic.pm
+++ b/lib/Plack/Middleware/Auth/Basic.pm
@@ -22,7 +22,9 @@ sub call {
     my $auth = $env->{HTTP_AUTHORIZATION}
         or return $self->unauthorized;
 
-    if ($auth =~ /^Basic (.*)$/) {
+    # note the 'i' on the regex, as, accoring to RFC2617 this is a 
+    # "case-insensitive token to identify the authentication scheme"
+    if ($auth =~ /^Basic (.*)$/i) {
         my($user, $pass) = split /:/, (MIME::Base64::decode($1) || ":");
         $pass = '' unless defined $pass;
         if ($self->authenticator->($user, $pass, $env)) {


### PR DESCRIPTION
```
11:46 < Trelane> seen miyagawa?
11:47 < Trelane>     if ($auth =~ /^Basic (.*)$/) {  
11:47 < Trelane> (in Plack::Middleware::Auth::Basic)
11:47 < Trelane>  HTTP provides a simple challenge-response authentication mechanism that 
                 MAY be used by a server to challenge a client request and by a client to 
                 provide authentication information. It uses an extensible, 
                 case-insensitive token to identify the authentication scheme, followed by 
                 a comma-separated list of attribute-value pairs which carry the parameters 
                 necessary for achieving authentication via that
11:48 < Trelane> http://tools.ietf.org/html/rfc2617#section-1.2
11:48 < Trelane> Does that regex need a /i at the end?
12:00 <@mst> sounds like it to me
```
