### PR TITLE
Decode a plus sign in cookies into a space

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -72,6 +72,9 @@ sub cookies {
         # trim leading trailing whitespace
         $pair =~ s/^\s+//; $pair =~ s/\s+$//;
 
+        # Apache2::Cookie encodes a space into a plus sign
+        $pair =~ tr/+/ /;
+
         my ($key, $value) = map URI::Escape::uri_unescape($_), split( "=", $pair, 2 );
 
         # Take the first one like CGI.pm or rack do

--- a/t/Plack-Request/cookie.t
+++ b/t/Plack-Request/cookie.t
@@ -13,6 +13,7 @@ my $app = sub {
     is $req->cookies->{Bar}, 'Baz';
     is $req->cookies->{XXX}, 'Foo Bar';
     is $req->cookies->{YYY}, 0;
+    is $req->cookies->{ZZZ}, 'Bar Baz';
 
     $req->new_response(200)->finalize;
 };
@@ -20,7 +21,7 @@ my $app = sub {
 test_psgi $app, sub {
     my $cb = shift;
     my $req = HTTP::Request->new(GET => "/");
-    $req->header(Cookie => 'Foo=Bar; Bar=Baz; XXX=Foo%20Bar; YYY=0; YYY=3');
+    $req->header(Cookie => 'Foo=Bar; Bar=Baz; XXX=Foo%20Bar; YYY=0; YYY=3; ZZZ=Bar+Baz');
     $cb->($req);
 };
 


### PR DESCRIPTION
Plack::Request::cookies can't handle cookies baked with Apach2::Cookie properly since Apach2::Cookie encodes a space in a cookie value into a plus sign.  Plack should accept a plus sign in a cookie value as a space.
