### PR TITLE
Fix parsing of QUERY_STRING for valueless keys.

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -83,7 +83,10 @@ sub cookies {
 
 sub query_parameters {
     my $self = shift;
-    $self->env->{'plack.request.query'} ||= Hash::MultiValue->new($self->uri->query_form);
+    my @combined = $self->uri->query_form;
+    @combined = (@combined, map { $_, '' } $self->uri->query_keywords);
+
+    $self->env->{'plack.request.query'} ||= Hash::MultiValue->new(@combined);
 }
 
 sub content {

--- a/t/Plack-Request/uri.t
+++ b/t/Plack-Request/uri.t
@@ -61,10 +61,24 @@ my @tests = (
     { add_env => {
         HTTP_HOST => 'example.com',
         SCRIPT_NAME => "",
+        QUERY_STRING => "foo_only"
+      },
+      uri => 'http://example.com/?foo_only',
+      parameters => { foo_only => '' } },
+    { add_env => {
+        HTTP_HOST => 'example.com',
+        SCRIPT_NAME => "",
+        QUERY_STRING => "foo&bar=baz"
+      },
+      uri => 'http://example.com/?foo&bar=baz',
+      parameters => { foo => '', bar => 'baz' } },
+    { add_env => {
+        HTTP_HOST => 'example.com',
+        SCRIPT_NAME => "",
         QUERY_STRING => 0
       },
       uri => 'http://example.com/?0',
-      parameters => {} },
+      parameters => { 0 => '' } },
     { add_env => {
         HTTP_HOST => 'example.com',
         SCRIPT_NAME => "/foo bar",


### PR DESCRIPTION
For a given 'QUERY_STRING: foo&bar=baz' the 'foo' parameter is not
accessible in Plack::Request::query_parameters(). There are a number of
applications using this pattern as a short way of passing information to
the handling code. This patch changes Plack::Request behaviour so that
foo makes its way in the underlaying Hash::MultiValue object as a key
with the empty string value. Application developers can now test the
existence of that key.
