### PR TITLE
PATCH: lighttpd "fix" broke mod_rewrite + IIS in Plack

### DIFF
--- a/lib/Plack/Handler/FCGI.pm
+++ b/lib/Plack/Handler/FCGI.pm
@@ -111,10 +111,12 @@ sub run {
         delete $env->{HTTP_CONTENT_TYPE};
         delete $env->{HTTP_CONTENT_LENGTH};
 
-        # lighttpd munges multiple slashes in PATH_INFO into one. Try recovering it
-        my $uri = URI->new("http://localhost" .  $env->{REQUEST_URI});
-        $env->{PATH_INFO} = uri_unescape($uri->path);
-        $env->{PATH_INFO} =~ s/^\Q$env->{SCRIPT_NAME}\E//;
+        if ($env->{SERVER_SOFTWARE} && $env->{SERVER_SOFTWARE} =~ m!lighttpd!) {
+            # lighttpd munges multiple slashes in PATH_INFO into one. Try recovering it
+            my $uri = URI->new("http://localhost" .  $env->{REQUEST_URI});
+            $env->{PATH_INFO} = uri_unescape($uri->path);
+            $env->{PATH_INFO} =~ s/^\Q$env->{SCRIPT_NAME}\E//;
+        }
 
         if ($env->{SERVER_SOFTWARE} && $env->{SERVER_SOFTWARE} =~ m!lighttpd[-/]1\.(\d+\.\d+)!) {
             no warnings;


### PR DESCRIPTION
Don't send me a patch, open a pull request on github. Thanks                                                                                                                                 

Sent from my iPhone                                                                                                                                                                          

On Thursday, June 28, 2012 at 6:52 AM, Thomas Zehetbauer wrote:                                                                                                                              

hi,                                                                                                                                                                                          

could you please include the attached patch with the next plack release?                                                                                                                     

we already reported this problem about eight months ago:  
http://grokbase.com/t/sc/catalyst/11aswtme3s/plack-hanlder-fcgi-bug                                                                                                                          

lighttpd should be fixed instead of breaking apache + IIS  
https://github.com/miyagawa/Plack/pull/284  
https://github.com/miyagawa/Plack/issues/299  
https://github.com/miyagawa/Plack/pull/300                                                                                                                                                   

TIA  
Tom                                                    
