### PR TITLE
Fix for Plack::Handler::FCGI and Catalist::Authentication::Credential::HTTP

### DIFF
--- a/lib/Plack/Handler/FCGI.pm
+++ b/lib/Plack/Handler/FCGI.pm
@@ -133,6 +133,10 @@ sub run {
             $env->{PATH_INFO} = '';
         }
 
+	if (defined(my $HTTP_AUTHORIZATION = $env->{Authorization})) {
+	    $env->{HTTP_AUTHORIZATION} = $HTTP_AUTHORIZATION;
+	}
+
         my $res = Plack::Util::run_app $app, $env;
 
         if (ref $res eq 'ARRAY') {


### PR DESCRIPTION
This commit copies $env->{Authorization} to $env->{HTTP_AUTHORIZATION} as Catalyst::Request filters out headers that don't match /^(HTTP|CONTENT|COOKIE)/i. Without the Authorization header Catalyst::Authentication::Credential::HTTP can't do its work.

See also: http://www.gossamer-threads.com/lists/catalyst/users/18321
