### PR TITLE
Iis redirect remove content

### DIFF
--- a/lib/Plack/Middleware/IIS7KeepAliveFix.pm
+++ b/lib/Plack/Middleware/IIS7KeepAliveFix.pm
@@ -1,0 +1,54 @@
+package Plack::Middleware::IIS7KeepAliveFix;
+
+use strict;
+use parent 'Plack::Middleware';
+use Plack::Util;
+
+sub call {
+    my($self, $env) = @_;
+        # Fixes buffer being cut off on redirect when keep-alive is active
+        my $res  = $self->app->($env);
+
+        Plack::Util::response_cb($res, sub {
+            my $res = shift;
+            if ($res->[0] =~ m!^30[123]$! ) {
+                Plack::Util::header_remove($res->[1], 'Content-Length');
+                Plack::Util::header_remove($res->[1], 'Content-Type');
+               return sub{ my $chunk; return unless defined $chunk; return ''; };
+            }
+
+            return;
+        });
+
+}
+
+1;
+__END__
+
+=head1 NAME
+
+Plack::Middleware::IIS7KeepAliveFix - fixes buffer being cut off on redirect when keep-alive is active on IIS.
+
+=head1 SYNOPSIS
+
+  # in your app.psgi
+  use Plack::Builder;
+
+  builder {
+    enable "IIS7KeepAliveFix";
+    $app;
+  };
+
+  # Or from the command line
+  plackup -s FCGI -e 'enable "IIS7KeepAliveFix"' /path/to/app.psgi
+
+=head1 DESCRIPTION
+
+This middleware fixes buffer being cut off on redirect when keep-alive is active on IIS7.
+
+=head1 AUTHORS
+
+KnowZeroX
+
+=cut
+

--- a/t/Plack-Middleware/iis7_keep_alive_fix.t
+++ b/t/Plack-Middleware/iis7_keep_alive_fix.t
@@ -1,0 +1,41 @@
+use strict;
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+use Plack::Middleware::IIS7KeepAliveFix;
+
+
+my $app=Plack::Middleware::IIS7KeepAliveFix->wrap(
+sub {
+    my $env = shift;
+
+
+    my $location='/go/?'.join('|', (0..1000));
+      return [ 302, [
+        'Content-Type' => 'text/html',
+        'Content-Length' => 285,
+        'Location' => $location,
+      ],[qq~<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Moved</title>
+  </head>
+  <body>
+     <p>This item has moved <a href="$location">here</a>.</p>
+  </body>
+</html>~] ];
+});
+
+
+test_psgi(app=>$app,client=> sub {
+    my $cb = shift;
+
+    my $res = $cb->(GET "/");
+
+    ok(!$res->content);
+    ok(!$res->content_length);
+    ok(!$res->content_type);
+});
+
+done_testing;
+


### PR DESCRIPTION
Middleware fix for errant IIS7 behavior, from a Catalyst bug: https://rt.cpan.org/Ticket/Display.html?id=78377
