### PR TITLE
Plack::Middleware::HTTPExceptions doc and test improvements

### DIFF
--- a/lib/Plack/Middleware/HTTPExceptions.pm
+++ b/lib/Plack/Middleware/HTTPExceptions.pm
@@ -135,7 +135,8 @@ catch and display, but you can also implement your own exception class
 to throw.
 
 If the thrown exception is not an object that implements either a
-C<code> or an C<as_psgi> method, a 500 error will be returned.
+C<code> or an C<as_psgi> method, a 500 error will be returned, and the
+exception is printed to the psgi.errors stream.
 Alternatively, you can pass a true value for the C<rethrow> parameter
 for this middleware, and the exception will instead be rethrown. This is
 enabled by default when C<PLACK_ENV> is set to C<development>, so that


### PR DESCRIPTION
- document that uncaught exceptions are sent to psgi.errors
- ...and tests that demonstrate this feature
