### PR TITLE
Correct timezone on systems where strftime doesn't support %z

### DIFF
--- a/lib/Plack/Middleware/AccessLog.pm
+++ b/lib/Plack/Middleware/AccessLog.pm
@@ -13,6 +13,13 @@ my %formats = (
 );
 
 use POSIX ();
+use Time::Local ();
+
+my $tzoffset = POSIX::strftime("%z", localtime) !~ /^[+-]\d{4}$/ && do {
+    my @t = localtime(time);
+    my $s = Time::Local::timegm(@t) - Time::Local::timelocal(@t);
+    sprintf '%+03d%02u', int($s/60/60), $s % (60*60)
+};
 
 sub call {
     my $self = shift;
@@ -35,9 +42,11 @@ sub log_line {
     my $h = Plack::Util::headers($headers);
 
     my $strftime = sub {
+        my ($fmt, @time) = @_;
+        $fmt =~ s/%z/$tzoffset/g if $tzoffset;
         my $old_locale = POSIX::setlocale(&POSIX::LC_ALL);
         POSIX::setlocale(&POSIX::LC_ALL, 'C');
-        my $out = POSIX::strftime(@_);
+        my $out = POSIX::strftime($fmt, @time);
         POSIX::setlocale(&POSIX::LC_ALL, $old_locale);
         return $out;
     };
@@ -106,6 +115,7 @@ sub _safe {
     $string;
 }
 
+1;
 
 __END__
 


### PR DESCRIPTION
An example log on Windows:

127.0.0.1 - - [15/Aug/2012:12:48:55 GMT Daylight Time] "GET / HTTP/1.
1" 200 1433 "-" "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.1 (KHTML, like Gec
ko) Chrome/21.0.1180.79 Safari/537.1"

With patch:

127.0.0.1 - - [15/Aug/2012:12:48:55 +0100] "GET / HTTP/1.
1" 200 1433 "-" "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.1 (KHTML, like Gec
ko) Chrome/21.0.1180.79 Safari/537.1"
