### PR TITLE
Set REMOTE_PORT environment variable

### DIFF
--- a/lib/HTTP/Server/PSGI.pm
+++ b/lib/HTTP/Server/PSGI.pm
@@ -112,6 +112,7 @@ sub accept_loop {
                 SERVER_NAME => $self->{host},
                 SCRIPT_NAME => '',
                 REMOTE_ADDR => $conn->peerhost,
+                REMOTE_PORT => $conn->peerport || 0,
                 'psgi.version' => [ 1, 1 ],
                 'psgi.errors'  => *STDERR,
                 'psgi.url_scheme' => $self->{ssl} ? 'https' : 'http',


### PR DESCRIPTION
REMOTE_PORT is a useful environment variable which can help ie. to track requests from the same user's session. It is not defined in RFC3875 but is commonly adapted by webservers.

This is the implementation for standard HTTP::Server::PSGI from Plack distribution.
