### PR TITLE
Plack::TempBuffer: pre-load Plack::TempBuffer::* modules

### DIFF
--- a/lib/Plack/TempBuffer.pm
+++ b/lib/Plack/TempBuffer.pm
@@ -1,8 +1,10 @@
 package Plack::TempBuffer;
 use strict;
 use warnings;
-use Plack::Util;
 use FileHandle; # for seek etc.
+use Plack::TempBuffer::PerlIO ();
+use Plack::TempBuffer::File ();
+use Plack::TempBuffer::Auto ();
 
 our $MaxMemoryBufferSize = 1024 * 1024;
 
@@ -29,7 +31,8 @@ sub new {
 
 sub create {
     my($class, $backend, $length, $max) = @_;
-    Plack::Util::load_class($backend, $class)->new($length, $max);
+    my $package = "$class\::$backend";
+    $package->new($length, $max);
 }
 
 sub print;


### PR DESCRIPTION
Change the Plack::TempBuffer module so that we pre-load the ::PerlIO,
::File and ::Auto modules. These modules are really small, and by
use-ing them here we'll have them pre-loaded in pre-forking
webservers.
