### PR TITLE
Plack::Handler::Apache[12]: delete $ENV{MOD_PERL}, don't just localize i...

### DIFF
--- a/lib/Plack/Handler/Apache1.pm
+++ b/lib/Plack/Handler/Apache1.pm
@@ -20,7 +20,17 @@ sub preload {
 sub load_app {
     my($class, $app) = @_;
     return $apps{$app} ||= do {
-        local $ENV{MOD_PERL}; # trick Catalyst/CGI.pm etc.
+        # Trick Catalyst, CGI.pm, CGI::Cookie and others that check
+        # for $ENV{MOD_PERL}.
+        #
+        # Note that we delete it instead of just localizing
+        # $ENV{MOD_PERL} because some users may check if the key
+        # exists, and we do it this way because "delete local" is new
+        # in 5.12:
+        # http://perldoc.perl.org/5.12.0/perldelta.html#delete-local
+        local $ENV{MOD_PERL};
+        delete $ENV{MOD_PERL};
+
         Plack::Util::load_psgi $app;
     };
 }

--- a/lib/Plack/Handler/Apache2.pm
+++ b/lib/Plack/Handler/Apache2.pm
@@ -28,7 +28,17 @@ sub preload {
 sub load_app {
     my($class, $app) = @_;
     return $apps{$app} ||= do {
-        local $ENV{MOD_PERL}; # trick Catalyst/CGI.pm etc.
+        # Trick Catalyst, CGI.pm, CGI::Cookie and others that check
+        # for $ENV{MOD_PERL}.
+        #
+        # Note that we delete it instead of just localizing
+        # $ENV{MOD_PERL} because some users may check if the key
+        # exists, and we do it this way because "delete local" is new
+        # in 5.12:
+        # http://perldoc.perl.org/5.12.0/perldelta.html#delete-local
+        local $ENV{MOD_PERL};
+        delete $ENV{MOD_PERL};
+
         Plack::Util::load_psgi $app;
     };
 }


### PR DESCRIPTION
...t

Some software such as CGI::Cookie does C<exists $ENV{MOD_PERL}> to
check if it's running under mod_perl instead of just checking whether
$ENV{MOD_PERL} is true.

Fix this by locally deleting $ENV{MOD_PERL} instead of just setting
its value to undef.

I hadn't used this construct before so I thought I'd check if it works
under a multitude of Perl versions, it works on at least 5.8.5 and
5.14.2:

```
$ perl -MData::Dumper -wle 'print $]; my %hash = qw(a b c d); { delete local $hash{a}; print Dumper \%hash } { local $hash{a}; print Dumper \%hash; }'
5.008005
$VAR1 = {
          'c' => 'd'
        };

$VAR1 = {
          'c' => 'd',
          'a' => undef
        };

$ perl5.14.2 -MData::Dumper -wle 'print $]; my %hash = qw(a b c d); { delete local $hash{a}; print Dumper \%hash } { local $hash{a}; print Dumper \%hash; }'
5.014002
$VAR1 = {
          'c' => 'd'
        };

$VAR1 = {
          'c' => 'd',
          'a' => undef
        };
```
