### PR TITLE
--path argument to mount app to specified sub-directory.

### DIFF
--- a/t/Plack-Runner/path.t
+++ b/t/Plack-Runner/path.t
@@ -1,0 +1,40 @@
+use strict;
+use Cwd;
+use File::Spec;
+use File::Temp;
+use LWP::UserAgent;
+use Test::More;
+use Test::TCP qw(empty_port);
+
+sub write_file($$){
+    my ( $path, $content ) = @_;
+    open my $out, '>', $path or die "$path: $!";
+    print $out $content;
+    close $out;
+}
+
+my $tmpdir  = File::Temp::tempdir( CLEANUP => 1 );
+my $psgi_file = File::Spec->catfile($tmpdir, 'app.psgi');
+write_file $psgi_file, qq/my \$app = sub {return [200, [], ["hello world"]]}\n/;
+
+my $port = empty_port();
+my $pid = fork;
+die $! unless ( defined $pid );
+if ($pid == 0) {
+    close STDERR;
+    exec($^X, 'bin/plackup', '-p', $port, '--path', '/app/', '-a', $psgi_file) or die $@;
+} else {
+    $SIG{INT} = 'IGNORE';
+    sleep 5;
+    my $ua = LWP::UserAgent->new;
+    my $res =  $ua->get("http://localhost:$port/");
+    is $res->code, 404;
+    $res =  $ua->get("http://localhost:$port/app/");
+    is $res->code, 200;
+    is $res->content, 'hello world';
+    kill 'INT', $pid;
+    wait;
+}
+
+done_testing;
+


### PR DESCRIPTION
I publish app via reverse proxy that opend always on my http server. So I want to start plack app without wrapper psgi script like following.

```
builder {
  mount '/foo/' => Plack::Util::load_psgi 'app.psgi';
}
```

I added `--path` argument similar to work like `unicorn_rails`. How about this?
Below is a usage to do it.

```
$ plackup -p 3000 --path /foo/
```
