### PR TITLE
fix errordocument for streaming responses in subrequests

### DIFF
--- a/lib/Plack/Middleware/ErrorDocument.pm
+++ b/lib/Plack/Middleware/ErrorDocument.pm
@@ -38,7 +38,24 @@ sub call {
             my $sub_r = $self->app->($env);
             if ($sub_r->[0] == 200) {
                 $r->[1] = $sub_r->[1];
-                $r->[2] = $sub_r->[2];
+                if (@$r == 3) {
+                    $r->[2] = $sub_r->[2];
+                }
+                else {
+                    my $full_sub_response = '';
+                    Plack::Util::foreach($sub_r->[2], sub {
+                        $full_sub_response .= $_[0];
+                    });
+
+                    my $returned;
+                    return sub {
+                        if ($returned) {
+                            return defined($_[0]) ? '' : undef;
+                        }
+                        $returned = 1;
+                        return $full_sub_response;
+                    }
+                }
             }
             # TODO: allow 302 here?
         } else {

--- a/t/Plack-Middleware/error_document_streaming_app.t
+++ b/t/Plack-Middleware/error_document_streaming_app.t
@@ -6,36 +6,83 @@ use HTTP::Request::Common;
 use Plack::Test;
 use Plack::Builder;
 
-my $handler = builder {
-    enable "Plack::Middleware::ErrorDocument",
-        404 => "$FindBin::Bin/errors/404.html";
+$Plack::Test::Impl = undef;
+my @impl = ('MockHTTP', 'Server');
+sub flip_backend {
+    push @impl, $Plack::Test::Impl;
+    $Plack::Test::Impl = shift @impl;
+}
 
-    sub {
-        my $env = shift;
-        my $status = ($env->{PATH_INFO} =~ m!status/(\d+)!)[0] || 200;
-        return sub {
-            my $r = shift;
-            my $w = $r->([ $status, [ 'Content-Type' => 'text/plain' ]]);
-            $w->write("Error: $status\n");
-            $w->close;
+{
+    my $handler = builder {
+        enable "Plack::Middleware::ErrorDocument",
+            404 => "$FindBin::Bin/errors/404.html";
+
+        sub {
+            my $env = shift;
+            my $status = ($env->{PATH_INFO} =~ m!status/(\d+)!)[0] || 200;
+            return sub {
+                my $r = shift;
+                my $w = $r->([ $status, [ 'Content-Type' => 'text/plain' ]]);
+                $w->write("Error: $status\n");
+                $w->close;
+            };
         };
     };
-};
 
-my @impl = qw(MockHTTP Server);
-sub flip_backend { $Plack::Test::Impl = shift @impl }
+    test_psgi app => $handler, client => sub {
+        my $cb = shift;
+        {
+            my $res = $cb->(GET "http://localhost/");
+            is $res->code, 200;
 
-test_psgi app => $handler, client => sub {
-    my $cb = shift;
-    {
-        my $res = $cb->(GET "http://localhost/");
-        is $res->code, 200;
+            $res = $cb->(GET "http://localhost/status/404");
+            is $res->code, 404;
+            like $res->header('content_type'), qr!text/html!;
+            like $res->content, qr/fancy 404/;
+        }
+    } while flip_backend;
+}
 
-        $res = $cb->(GET "http://localhost/status/404");
-        is $res->code, 404;
-        like $res->header('content_type'), qr!text/html!;
-        like $res->content, qr/fancy 404/;
-    }
-} while flip_backend;
+{
+    my $handler = builder {
+        enable "Plack::Middleware::ErrorDocument",
+            404 => "/404", subrequest => 1;
+
+        mount '/404' => sub {
+            [200, ['Content-Type' => 'text/html'], [<<ERROR]]
+a
+b
+c
+
+This is a fancy 404 page.
+ERROR
+        };
+
+        mount '/' => sub {
+            my $env = shift;
+            my $status = ($env->{PATH_INFO} =~ m!status/(\d+)!)[0] || 200;
+            return sub {
+                my $r = shift;
+                my $w = $r->([ $status, [ 'Content-Type' => 'text/plain' ]]);
+                $w->write("Error: $status\n");
+                $w->close;
+            };
+        };
+    };
+
+    test_psgi app => $handler, client => sub {
+        my $cb = shift;
+        {
+            my $res = $cb->(GET "http://localhost/");
+            is $res->code, 200;
+
+            $res = $cb->(GET "http://localhost/status/404");
+            is $res->code, 404;
+            like $res->header('content_type'), qr!text/html!;
+            like $res->content, qr/fancy 404/;
+        }
+    } while flip_backend;
+}
 
 done_testing;


### PR DESCRIPTION
Assigning directly to $res->[2] is wrong here, because the app itself could be using streaming, in which case it expects to receive a writer object back, but servers determine whether to return a writer object based on if the third element exists.
