### PR TITLE
Feature: allow to passing any init parameters to FCGI::ProcManager::XXX

### DIFF
--- a/lib/Plack/Handler/FCGI.pm
+++ b/lib/Plack/Handler/FCGI.pm
@@ -23,7 +23,15 @@ sub new {
     $self->{listen}      ||= [ ":$self->{port}" ] if $self->{port}; # compatibility
     $self->{backlog}     ||= 100;
     $self->{manager}     = 'FCGI::ProcManager' unless exists $self->{manager};
-    $self->{manager_args} = [split /\s+/, ($self->{manager_args} || '')];
+    $self->{manager_args} ||= [];
+
+    if (!ref $self->{manager_args}) {
+        $self->{manager_args} = [split /\s+/, ($self->{manager_args} || '')];
+    } elsif (ref $self->{manager_args} eq 'HASH') {
+        $self->{manager_args} = [%{$self->{manager_args}}];
+    } elsif (ref $self->{manager_args} ne 'ARRAY') {
+        die 'Invalid manager_args value';
+    }
 
     $self;
 }


### PR DESCRIPTION
When I tried to use  FCGI::ProcManager::Dynamic as custom proc manager, 
I found then has no possibility to set most important FCGI::ProcManager::Dynamic options like min_nproc, max_proc, delta_nproc.. 

And I add "manager_args" parameter then passed to FCGI::ProcManager::XXX->new(..).

And now easy set any paramenters from command-line:

plackup XXX -s FCGI  --manager FCGI::ProcManager::Dynamic --manager_args "min_nproc 4 max_nproc 40 delta_nproc 5" 
