### PR TITLE
Plack::Middleware::AccessLog: calculation of $tzoffset fails for certain time zones

### DIFF
--- a/lib/Plack/Middleware/AccessLog.pm
+++ b/lib/Plack/Middleware/AccessLog.pm
@@ -13,12 +13,12 @@ my %formats = (
 );
 
 use POSIX ();
-use Time::Local ();
 
 my $tzoffset = POSIX::strftime("%z", localtime) !~ /^[+-]\d{4}$/ && do {
-    my @t = localtime(time);
-    my $s = Time::Local::timegm(@t) - Time::Local::timelocal(@t);
-    sprintf '%+03d%02u', int($s/3600), $s % 3600;
+    require Time::Local;
+    my @t = localtime;
+    my $s = int(Time::Local::timegm(@t) - Time::Local::timelocal(@t)) / 60;
+    sprintf '%+03d%02u', $s / 60, $s % 60;
 };
 
 sub call {


### PR DESCRIPTION
Fix for time zones, that are not on full hour offsets.

The code in Plack::Middleware::AccessLog was broken for time zones, that don't have full hour offsets.

Example, that illustrates how the implementation failed for +03:30 (Iran):
# > perl -wE 'my $s = 3_60_60 + 30*60; printf "%+03d%02u\n", int($s/3600), $s % 3600;'

+031800

The patch also loads Time::Local only if it is actually needed (in most cases it is not).
