### PR TITLE
Plack::Handler::Apache2: normalize duplicate Content-Length headers

### DIFF
--- a/lib/Plack/Handler/Apache2.pm
+++ b/lib/Plack/Handler/Apache2.pm
@@ -68,6 +68,15 @@ sub call_app {
         $env->{HTTP_AUTHORIZATION} = $HTTP_AUTHORIZATION;
     }
 
+    # If you supply more than one Content-Length header Apache will
+    # happily concat the values with ", ", e.g. "72, 72". This
+    # violates the PSGI spec so fix this up and just take the first
+    # one.
+    if (exists $env->{CONTENT_LENGTH} && $env->{CONTENT_LENGTH} =~ /,/) {
+        no warnings qw(numeric);
+        $env->{CONTENT_LENGTH} = int $env->{CONTENT_LENGTH};
+    }
+
     # Actually, we can not trust PATH_INFO from mod_perl because mod_perl squeezes multiple slashes into one slash.
     my $uri = URI->new("http://".$r->hostname.$r->unparsed_uri);
 


### PR DESCRIPTION
If you supply multiple Content-Length headers, e.g.:

```
Content-Length: 72
Content-Length: 72
Content-Length: 72
```

Apache will happily produce this for you:

```
CONTENT_LENGTH => 72, 72, 72
```

This behavior isn't compliant with the PSGI
spec (https://metacpan.org/module/PSGI) which states:

```
CONTENT_LENGTH: The length of the content in bytes, as an
integer. The presence or absence of this key should correspond to
the presence or absence of HTTP Content-Length header in the
request.
```

So patch up Plack::Handler::Apache2 to be compliant and always provide
an integer instead of some concatenated gibberish.
