### PR TITLE
Fix PATH_INFO check

### DIFF
--- a/lib/Plack/Middleware/Lint.pm
+++ b/lib/Plack/Middleware/Lint.pm
@@ -42,7 +42,7 @@ sub validate_env {
     unless (defined($env->{PATH_INFO})) { # allows empty string
         die('Missing mandatory env param: PATH_INFO');
     }
-    if ($env->{PATH_INFO} !~ m!^/!) {
+    if ($env->{PATH_INFO}!='' & $env->{PATH_INFO} !~ m!^/!) {
         die('PATH_INFO must begin with / ($env->{SCRIPT_NAME})');
     }
     unless (defined($env->{SERVER_NAME})) {


### PR DESCRIPTION
PATH_INFO can content empty string.
rfc3875:  PATH_INFO = "" | ( "/" path )
