### PR TITLE
Delete invalid fastcgi_param passed from nginx

### DIFF
--- a/lib/Plack/Handler/FCGI.pm
+++ b/lib/Plack/Handler/FCGI.pm
@@ -121,6 +121,12 @@ sub run {
             $env->{PATH_INFO} = '';
         }
 
+        # typical fastcgi_param from nginx might get empty values
+        for my $key (qw(CONTENT_TYPE CONTENT_LENGTH)) {
+            no warnings;
+            delete $env->{$key} if exists $env->{$key} && $env->{$key} eq '';
+        }
+
         if (defined(my $HTTP_AUTHORIZATION = $env->{Authorization})) {
             $env->{HTTP_AUTHORIZATION} = $HTTP_AUTHORIZATION;
         }


### PR DESCRIPTION
lines like `fastcgi_param CONTENT_LENGTH $content_legnth` in nginx.conf would generate an empty ("") value of CONTENT_LENGTH in environment variables, which results in an invalid PSGI variables.

Lint doesn't warn about this (although it probably should) and Plack::App::Proxy in particular uses this to construct an empty Content-Length header in an outgoing request, which could choke the backend.
