### PR TITLE
Check if a string contains wide string, by actually printing it to a dummy handle

### DIFF
--- a/lib/Plack/Middleware/Lint.pm
+++ b/lib/Plack/Middleware/Lint.pm
@@ -164,9 +164,10 @@ sub _has_wide_strings {
 
     my $warnings = '';
     {
+        use warnings;
         local $SIG{__WARN__} = sub { $warnings .= $_[0] };
         open my $io, ">", \(my $null);
-        $io->print($str);
+        print {$io} $str;
     }
 
     $warnings =~ /Wide character in print/;


### PR DESCRIPTION
The Lint's utf-8/wide-strings check currently uses `utf8::is_utf8` _and_ whether the string actually contains the high bit. Based on my experience this should work as expected but it is basically testing what is inside, rather than how it behaves.

This patch makes the check by actually printing to a dummy IO and see if the warning is emitted.
