### PR TITLE
Always return content => '' for empty response bodies

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Go to http://github.com/plack/Plack/issues for the roadmap and known issues.
 
+        - HTTP::Message::PSGI::res_from_psgi now always returns empty string
+          for an empty response body, so streamed responses are consistent with
+          non-streamed (ether)
+
 1.0014 Mon Dec  3 10:27:43 PST 2012
     [BUG FIXES]
         - Fixed Hash order in tests for perl 5.17 (doy)

--- a/lib/HTTP/Message/PSGI.pm
+++ b/lib/HTTP/Message/PSGI.pm
@@ -120,7 +120,7 @@ sub _res_from_psgi {
             $res->content(join '', grep defined, @$body);
         } else {
             local $/ = \4096;
-            my $content;
+            my $content = '';
             while (defined(my $buf = $body->getline)) {
                 $content .= $buf;
             }

--- a/t/HTTP-Message-PSGI/empty_streamed_response.t
+++ b/t/HTTP-Message-PSGI/empty_streamed_response.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More;
+use HTTP::Message::PSGI;
+use Plack::Middleware::AccessLog::Timed;
+use HTTP::Request;
+use HTTP::Response;
+
+# Plack::Middleware::AccessLog::Timed is used here as it always uses
+# a coderef in response_cb to wrap the response body.
+my $app = Plack::Middleware::AccessLog::Timed->wrap(
+    sub { return [ 200, [], []] },
+    logger => sub {},
+);
+
+my $env = req_to_psgi(HTTP::Request->new(POST => "http://localhost/post", [ ], 'hello'));
+
+my $response = HTTP::Response->from_psgi($app->($env));
+
+is($response->content, '', 'undef response body converted to empty string');
+
+done_testing;
+


### PR DESCRIPTION
Previously, streamed responses returned content => undef, which leads to inconsistent results in tests when middleware is changed (e.g. P:M:AccessLog switched to ::Timed).
