### PR TITLE
Plack::Middleware::Static: add ability to pass $env to callbacks

### DIFF
--- a/lib/Plack/Middleware/Static.pm
+++ b/lib/Plack/Middleware/Static.pm
@@ -25,7 +25,7 @@ sub _handle_static {
     my $path = $env->{PATH_INFO};
 
     for ($path) {
-        my $matched = 'CODE' eq ref $path_match ? $path_match->($_) : $_ =~ $path_match;
+        my $matched = 'CODE' eq ref $path_match ? $path_match->($_, $env) : $_ =~ $path_match;
         return unless $matched;
     }
 
@@ -36,6 +36,8 @@ sub _handle_static {
 
 1;
 __END__
+
+=encoding utf8
 
 =head1 NAME
 
@@ -96,6 +98,11 @@ The callback should operate on C<$_> and return a true or false value. Any
 changes it makes to C<$_> are used when looking for the static file in the
 C<root>.
 
+In addition to C<$_> being set the callback receives two arguments,
+C<$_> and C<$env>. You can inspect C<$env> for more advanced static
+handling, e.g. giving different static assets to different user
+agents.
+
 The configuration above serves C</static/foo.png> from
 C<static-files/foo.png>, not C<static-files/static/foo.png>. The callback
 specified in the C<path> option matches against C<$_> munges this value using
@@ -115,7 +122,7 @@ the request on to the application it is wrapping.
 
 =head1 AUTHOR
 
-Tokuhiro Matsuno, Tatsuhiko Miyagawa
+Tokuhiro Matsuno, Tatsuhiko Miyagawa, Ævar Arnfjörð Bjarmason
 
 =head1 SEE ALSO
 

--- a/t/Plack-Middleware/static.t
+++ b/t/Plack-Middleware/static.t
@@ -15,6 +15,9 @@ my $handler = builder {
     enable "Plack::Middleware::Static",
         path => sub { s!^/share/!!}, root => "share";
     enable "Plack::Middleware::Static",
+        path => sub { s!^/more_share/!! if $_[1]->{PATH_INFO} =~ m!^/more_share/!  },
+        root => "share";
+    enable "Plack::Middleware::Static",
         path => sub { s!^/share-pass/!!}, root => "share", pass_through => 1;
     enable "Plack::Middleware::Static",
         path => qr{\.(t|PL|txt)$}i, root => '.';
@@ -55,6 +58,11 @@ my %test = (
 
         {
             my $res = $cb->(GET "http://localhost/share/face.jpg");
+            is $res->content_type, 'image/jpeg';
+        }
+
+        {
+            my $res = $cb->(GET "http://localhost/more_share/face.jpg");
             is $res->content_type, 'image/jpeg';
         }
 


### PR DESCRIPTION
Change the callback interface for static middleware to pass $env to
the callbacks in addition to setting $_ and passing $_ as the first
argument.

Some middleware might want to look at other things in $env, or consult
some object we previously stuck in $env instead of just looking at
$env->{PATH_INFO}. This adds the ability to easily do that.

Chat about an earlier version of this patch on #plack which instead of
just adding $env to the arguments passed to the callaback. See
https://github.com/plack/Plack/pull/363.

```
17:29:43 < miyagawa> avar: quite honestly i don't like the pattern you often come up with, that changes callback signature with other options
17:33:20 < avar> miyagawa: How would you add that to the API while preserving compatibility? Add another option with a sub that has a different signature?
17:36:55 < miyagawa> avar: yes, or in this case pass $env as a second arg
17:37:08 < miyagawa> OR, you write a completely new middleware as a subclass
17:37:35 < miyagawa> i don't know what you actually want to achieve
17:37:39 < miyagawa> "some middleware might" isn't a use case
17:38:35 < avar> If you think breaking "my $path = pop" is fine that's fine by me. I was going for something that wouldn't ever break existing stuff without explicitly declaring what you wanted.
17:40:45 < miyagawa> this is not POE nobody would ever use pop
17:41:08 < miyagawa> but then you can also use other option like you said
17:41:48 < miyagawa> and again i don't see a use case
17:42:36 < avar> I'm setting up a Plack::Request object early in another middleware that everything else has access to, also an object in $env you can log against.
17:42:51 < avar> Not having to set that up again + being able to log with that object you pass around is handy
17:48:30 < miyagawa> nobody would use $path = shift either because the interface is $_
17:48:50 < miyagawa> but don't take that as a suggestion to completely change that
17:49:22 < avar> Why is it passing $_ in addition to setting it in the first place?
17:50:05 < miyagawa> i guess no app will break if you don't pass it
17:50:31 < avar> well some might be doing: my ($path) = @_;
17:50:51 < doy> which still wouldn't break
17:51:28 < miyagawa> yeah.
17:51:41 < miyagawa> the documentation says nothing about the argument anyway
17:51:42 < miyagawa> BUT
17:51:56 < miyagawa> i think your use case is pretty odd
17:52:04 < doy> yeah, the documentation explicitly says "The callback should operate on $_ and return a true or false value."
17:52:11 < miyagawa> and that it has to be handled separately than adding a new argument to "path:"
17:52:41 < miyagawa> right
17:53:04 < miyagawa> I think the easiest compromise would be to pass $path, $env to the callback :)
17:54:41 < avar> Sure, works for me. For what it's worth I don't usually write APIs with odd semantics like this, I was just going for something that didn't break the documented or implicit API
```
