### PR TITLE
New preferred Builder API 

### DIFF
--- a/lib/Plack/Builder.pm
+++ b/lib/Plack/Builder.pm
@@ -162,34 +162,10 @@ Plack::Builder - OO and DSL to enable Plack Middlewares
   };
 
   # using OO interface
-
-  # Just add middleware
   my $builder = Plack::Builder->new;
   $builder->add_middleware('Foo', opt => 1);
   $builder->add_middleware('Bar');
   $builder->wrap($app);
-
-  # With mount
-  my $builder = Plack::Builder->new;
-  $builder->add_middleware('Foo', opt => 1);
-  $builder->mount('/foo' => $foo_app);
-  $builder->mount('/' => $root_app);
-  $builder->to_app;
-
-  # Nested builders. Equivalent to:
-  # builder {
-  #     mount '/foo' => builder {
-  #         enable 'Foo';
-  #         $app;
-  #     };
-  #     mount '/' => $app2;
-  # };
-  my $builder_out = Plack::Builder->new;
-  my $builder_in  = Plack::Builder->new;
-  $builder_in->add_middleware('Foo');
-  $builder_out->mount("/foo" => $builder_in->wrap($app));
-  $builder_out->mount("/" => $app2);
-  $builder_out->to_app;
 
 =head1 DESCRIPTION
 
@@ -317,8 +293,46 @@ which is located under C</foo> because of the outer C<builder> block.
 =head1 CONDITIONAL MIDDLEWARE SUPPORT
 
 You can use C<enable_if> to conditionally enable middleware based on
-the runtime environment. See L<Plack::Middleware::Conditional> for
-details.
+the runtime environment.
+
+  builder {
+      enable_if { $_[0]->{REMOTE_ADDR} eq '127.0.0.1' } 'StackTrace', force => 1;
+      $app;
+  };
+
+See L<Plack::Middleware::Conditional> for details.
+
+=head1 OBJECT ORIENTED INTERFACE
+
+Object oriented interface supports the same functionality with the DSL
+version in a clearer interace, probably with more typing required.
+
+  # With mount
+  my $builder = Plack::Builder->new;
+  $builder->add_middleware('Foo', opt => 1);
+  $builder->mount('/foo' => $foo_app);
+  $builder->mount('/' => $root_app);
+  $builder->to_app;
+
+  # Nested builders. Equivalent to:
+  # builder {
+  #     mount '/foo' => builder {
+  #         enable 'Foo';
+  #         $app;
+  #     };
+  #     mount '/' => $app2;
+  # };
+  my $builder_out = Plack::Builder->new;
+  my $builder_in  = Plack::Builder->new;
+  $builder_in->add_middleware('Foo');
+  $builder_out->mount("/foo" => $builder_in->wrap($app));
+  $builder_out->mount("/" => $app2);
+  $builder_out->to_app;
+
+  # conditional. You can also directly use Plack::Middleware::Conditional
+  my $builder = Plack::Builder->new;
+  $builder->add_middleware_if(sub { $_[0]->{REMOTE_ADDR} eq '127.0.0.1' }, 'StackTrace');
+  $builder->wrap($app);
 
 =head1 SEE ALSO
 

--- a/t/Plack-Builder/oo_interface.t
+++ b/t/Plack-Builder/oo_interface.t
@@ -40,6 +40,14 @@ sub test_app {
 
 {
     my $builder = Plack::Builder->new;
+    $builder->add_middleware_if(sub { $_[0]->{HTTP_HOST} eq 'localhost' }, 'Runtime');
+    $builder->add_middleware('XFramework', framework => 'Plack::Builder');
+    $builder->mount('/app/foo/bar' => $app);
+    test_app $builder->to_app;
+}
+
+{
+    my $builder = Plack::Builder->new;
     $builder->add_middleware('Runtime');
     eval { $builder->to_app };
     like $@, qr/called without mount/, $@;


### PR DESCRIPTION
Plack::Builder has had its OO API, but the way `->mount` and `->to_app` works is kind of weird and requires you to pass around the `$app` to make it work.

This patch fixes it by preserving the urlmap state inside (as it is designed), and allows you to more naturally write:

``` perl
use Plack::Builder;

my $builder = Plack::Builder->new;
$builder->add_middleware('Foo');
$builder->mount('/foo' => $foo);
$builder->to_app;
```

in case you don't need mount feature there's a `->wrap` method which is basically the equivalent of putting `$app` in the last line of `builder {}` block DSL.

This preserves the existing (unfortunately documented) API, and passes the test for it as well. We can add a deprecation warning if we plan to eliminate that compatibility but that's not much of a big deal at this moment.
