### PR TITLE
Added custom log formats %m, %U, %q and %H by Plack::Middleware::AccessLog

### DIFF
--- a/lib/Plack/Middleware/AccessLog.pm
+++ b/lib/Plack/Middleware/AccessLog.pm
@@ -85,6 +85,10 @@ sub log_line {
         V => sub { $env->{HTTP_HOST} || $env->{SERVER_NAME} || '-' },
         p => sub { $env->{SERVER_PORT} },
         P => sub { $$ },
+        m => sub { _safe($env->{REQUEST_METHOD}) },
+        U => sub { _safe($env->{PATH_INFO}) },
+        q => sub { ($env->{QUERY_STRING} ne '') ? '?' . _safe($env->{QUERY_STRING}) : '' },
+        H => sub { $env->{SERVER_PROTOCOL} },
     );
 
     my $char_handler = sub {
@@ -184,6 +188,10 @@ L<Apache's LogFormat templates|http://httpd.apache.org/docs/2.0/mod/mod_log_conf
    %V    HTTP_HOST or SERVER_NAME from the PSGI environment, or -
    %p    SERVER_PORT from the PSGI environment
    %P    the worker's process id
+   %m    REQUEST_METHOD from the PSGI environment
+   %U    PATH_INFO from the PSGI environment
+   %q    QUERY_STRING from the PSGI environment
+   %H    SERVER_PROTOCOL from the PSGI environment
 
 Some of these format fields are only supported by middleware that subclasses C<AccessLog>.
 

--- a/t/Plack-Middleware/access_log.t
+++ b/t/Plack-Middleware/access_log.t
@@ -38,4 +38,22 @@ my $test = sub {
     is $log, '-';
 }
 
+{
+    my $req = GET "http://example.com/";
+    my $fmt = "%r == %m %U%q %H";
+    $test->($fmt)->($req);
+    chomp $log;
+    my ($r, $rs) = split / == /, $log;
+    is $r, $rs;
+}
+
+{
+    my $req = GET "http://example.com/foo?bar=baz";
+    my $fmt = "%r == %m %U%q %H";
+    $test->($fmt)->($req);
+    chomp $log;
+    my ($r, $rs) = split / == /, $log;
+    is $r, $rs;
+}
+
 done_testing;


### PR DESCRIPTION
Support following additional custom log formats compatible with apache2 mod_log_config by Plack::Middleware::AccessLog to get individual values of "%r":
- %m - request method
- %U - request URL (not included query string)
- %q - query string
- %H - protocol
