### PR TITLE
WIP: Add Plack::Util::convert_to_app($app) for warnings

### DIFF
--- a/lib/Plack/Builder.pm
+++ b/lib/Plack/Builder.pm
@@ -124,7 +124,7 @@ sub builder(&) {
         }
     }
 
-    $app = $app->to_app if $app and Scalar::Util::blessed($app) and $app->can('to_app');
+    $app = Plack::Util::convert_to_app($app);
 
     $self->to_app($app);
 }

--- a/lib/Plack/Component.pm
+++ b/lib/Plack/Component.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Carp ();
 use Plack::Util;
-use overload '&{}' => \&to_app_auto, fallback => 1;
+use overload '&{}' => \&to_app, fallback => 1;
 
 sub new {
     my $proto = shift;
@@ -17,17 +17,6 @@ sub new {
     }
 
     $self;
-}
-
-sub to_app_auto {
-    my $self = shift;
-    if (($ENV{PLACK_ENV} || '') eq 'development') {
-        my $class = ref($self);
-        warn "WARNING: Automatically converting $class instance to a PSGI code reference. " .
-          "If you see this warning for each request, you probably need to explicitly call " .
-          "to_app() i.e. $class->new(...)->to_app in your PSGI file.\n";
-    }
-    $self->to_app(@_);
 }
 
 # NOTE:

--- a/lib/Plack/Runner.pm
+++ b/lib/Plack/Runner.pm
@@ -21,7 +21,7 @@ sub new {
 sub build(&;$) {
     my $block = shift;
     my $app   = shift || sub { };
-    return sub { $block->($app->()) };
+    return sub { Plack::Util::convert_to_app($block->($app->())) };
 }
 
 sub parse_options {

--- a/lib/Plack/Util.pm
+++ b/lib/Plack/Util.pm
@@ -136,6 +136,19 @@ sub load_psgi {
     return $app;
 }
 
+sub convert_to_app {
+    my $app = shift;
+
+    if (Scalar::Util::blessed($app) && overload::Method($app, '&{}')) {
+        if (($ENV{PLACK_ENV} || '') eq 'development') {
+            warn "WARNING: Converting $app to PSGI code reference using &{} overloading. You probably forgot to call ->to_app etc. in your .psgi file!\n";
+        }
+        $app = \&$app;
+    }
+
+    $app;
+}
+
 sub run_app($$) {
     my($app, $env) = @_;
 


### PR DESCRIPTION
WIP, since it gives some inconsistent warning when you use URLMap or manually apply middleware etc.

```
11:16 haarg: one concern is URLMap
11:16 miyagawa: the explicit URLMap or implicit?
11:17 haarg: seems like with that change you wouldn't get a warning but you would get per-request ->to_app for things mounted in a builder
11:17 miyagawa: oooh
11:18 miyagawa: good catch :)
11:18 miyagawa: but that's been the case already (till the change)
11:18 haarg: manually using middleware ->wrap() would also escape the warning
11:19 miyagawa: i could make to_app overload warn twice, or do the convert_to_app thing in URLmap
11:19 ether: it should be possible to recreate each of these scenarios in a unit test and catch the warnings with Test::Warn
11:19 haarg: that's why i was concerned about trying to do the checks in many places
11:19 miyagawa: it kinda annoys plackup -e 'Plack::App::File->new' warns though. Tried to special case -e (eval) but it looked a little complicated
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/plack/plack/373)

<!-- Reviewable:end -->
