### PR TITLE
See issue 376

### DIFF
--- a/lib/Plack/Middleware/SimpleContentFilter.pm
+++ b/lib/Plack/Middleware/SimpleContentFilter.pm
@@ -13,6 +13,7 @@ sub call {
     $self->response_cb($res, sub {
         my $res = shift;
         my $h = Plack::Util::headers($res->[1]);
+        return unless $h->get('Content-Type');
         if ($h->get('Content-Type') =~ m!^text/!) {
             return sub {
                 my $chunk = shift;


### PR DESCRIPTION
Code which makes it so that Plack::MiddleWare::SimpleContentFilter does not throw a warning when there is no Content-Type header.
