### PR TITLE
Optimize Plack::Request->query_parameters

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -100,7 +100,7 @@ sub query_parameters {
                 split(/\+/, $query_string, -1);
         }
     }
-    $env->{'plack.request.query'} ||= Hash::MultiValue->new(@query);
+    $env->{'plack.request.query'} = Hash::MultiValue->new(@query);
 }
 
 sub content {


### PR DESCRIPTION
- Old code used build an URI object (twice!), but for query parameter
  parsing, this is unnecessary
- Stole code from URI::_query, directly created Hash::MultiValue
- While we're at it, short-circuit the method by checking for cached
  instance before doing any parsing
- This patch should make query parameter parsing about 5~10 times faster
