### PR TITLE
Topic/accesslog private methods

### DIFF
--- a/lib/Plack/Middleware/AccessLog.pm
+++ b/lib/Plack/Middleware/AccessLog.pm
@@ -38,9 +38,9 @@ sub call {
 }
 
 sub log_line {
-    my($self, $status, $headers, $env, $opts) = @_;
+    my($self, $status, $response_headers, $env, $opts) = @_;
 
-    my $h = Plack::Util::headers($headers);
+    my $h = Plack::Util::headers($response_headers);
 
     my $fmt = $self->format || "combined";
     $fmt = $formats{$fmt} if exists $formats{$fmt};


### PR DESCRIPTION
I am creating Plack::Middleware::AccessLog::Custom which allows the customization that I did in pull request #381 that you rejected.  Here in this branch I have pulled out the handler methods so they can be called by the subclass.  There is no change in functionality here, other than adding support for uppercased block handlers.

I hope this is acceptable, as it will make it possible to log some things that are currently not loggable, such as additional fields from $env (such as CONTENT_LENGTH, CONTENT_TYPE).
