### PR TITLE
Remove my declaration warning

### DIFF
--- a/t/Plack-Middleware/auth_basic.t
+++ b/t/Plack-Middleware/auth_basic.t
@@ -30,7 +30,7 @@ test_psgi app => $app, client => sub {
     is $res->code, 200;
     is $res->content, "Hello admin";
 
-    my $req = GET "http://localhost/", "Authorization" => "Basic am9objpmb286YmFy";
+    $req = GET "http://localhost/", "Authorization" => "Basic am9objpmb286YmFy";
     $res = $cb->($req);
     is $res->code, 200;
     is $res->content, "Hello john";


### PR DESCRIPTION
removed following warning:

```
t/Plack-Middleware/auth_basic.t .................... "my" variable $req masks earlier declaration in same scope at t/Plack-Middleware/auth_basic.t line 33.
t/Plack-Middleware/auth_basic.t .................... ok  
```
