### PR TITLE
Make restarter ignore Emacs lock files

### DIFF
--- a/lib/Plack/Loader/Restarter.pm
+++ b/lib/Plack/Loader/Restarter.pm
@@ -52,7 +52,7 @@ sub valid_file {
     if ( $file->{path} =~ m{(\d+)$} && $1 >= 4913 && $1 <= 5036) {
         return 0;
     }
-    $file->{path} !~ m!\.(?:git|svn)[/\\]|\.(?:bak|swp|swpx|swx)$|~$|_flymake\.p[lm]$!;
+    $file->{path} !~ m!\.(?:git|svn)[/\\]|\.(?:bak|swp|swpx|swx)$|~$|_flymake\.p[lm]$|\.#!;
 }
 
 sub run {

--- a/t/Plack-Loader/restarter_valid.t
+++ b/t/Plack-Loader/restarter_valid.t
@@ -12,6 +12,7 @@ my @ignore = qw(
     .git/123 .svn/abc Foo.pm~ _flymake.pl /Users/joe/foo.pl~ /foo/bar/x.txt.bak
     /path/to/foo.swp /path/to/foo.swpx /path/to/foo.swx
     /path/to/4913 /path/to/5036
+    /path/to/.#Foo.pm
 );
 
 ok $r->valid_file({ path => $_ }), "$_ is valid" for @match;


### PR DESCRIPTION
which are being created when user modifies some file.

Emacs creates symbolic link in same directory as modified file and
prepends ".#" to the file name.

So when user edits /some/path/Foo.pm Emacs creates /some/path/.#Foo.pm

http://www.gnu.org/software/emacs/manual/html_node/emacs/Interlocking.html
