### PR TITLE
suppress Test::TCP warnings

### DIFF
--- a/lib/Plack/Test/Server.pm
+++ b/lib/Plack/Test/Server.pm
@@ -29,6 +29,7 @@ sub test_psgi {
             my $port = shift;
             my $server = Plack::Loader->auto(port => $port, host => ($args{host} || '127.0.0.1'));
             $server->run($app);
+            exit;
         },
     );
 }


### PR DESCRIPTION
For suppress Test::TCP warnings like "[Test::TCP] Child process does not block(PID: 3xxxx, PPID: 3xxxx)", 
Plack::Test::Server needs exit() at the end of server block.
