### PR TITLE
fix warning with oo version of Plack::Builder in development env

### DIFF
--- a/lib/Plack/Builder.pm
+++ b/lib/Plack/Builder.pm
@@ -56,6 +56,8 @@ sub to_app {
     if ($app) {
         $self->wrap($app);
     } elsif ($self->{_urlmap}) {
+        $self->{_urlmap} = $self->{_urlmap}->to_app
+            if Scalar::Util::blessed($self->{_urlmap});
         $self->wrap($self->{_urlmap});
     } else {
         Carp::croak("to_app() is called without mount(). No application to build.");

--- a/t/Plack-Builder/oo_interface.t
+++ b/t/Plack-Builder/oo_interface.t
@@ -62,4 +62,16 @@ sub test_app {
     like $warn[0], qr/mappings to be ignored/;
 }
 
+{
+    local $ENV{PLACK_ENV} = 'development';
+    my @warn;
+    local $SIG{__WARN__} = sub { push @warn, @_ };
+    my $builder = Plack::Builder->new;
+    $builder->add_middleware('Runtime');
+    $builder->add_middleware('XFramework', framework => 'Plack::Builder');
+    $builder->mount('/app/foo/bar' => $app);
+    test_app $builder->to_app;
+    is_deeply(\@warn, [], "no warnings");
+}
+
 done_testing;


### PR DESCRIPTION
Make the OO version of the Plack::Builder API also avoid the warning about automatically calling to_app.
