### PR TITLE
Add "app_builder" type of argument for Plack::Runner

### DIFF
--- a/lib/Plack/Runner.pm
+++ b/lib/Plack/Runner.pm
@@ -160,6 +160,10 @@ sub locate_app {
         return sub { $psgi };
     }
 
+    if (ref $psgi eq 'REF' and ref $$psgi eq 'CODE') {
+        return $$psgi;
+    }
+
     if ($self->{eval}) {
         $self->loader->watch("lib");
         return build {
@@ -294,6 +298,20 @@ Plack::Runner - plackup core
   my $runner = Plack::Runner->new;
   $runner->parse_options(@ARGV);
   $runner->run($app);
+
+  # use app builder instead of app
+  use Plack::Runner;
+  my $app_builder => sub {
+          # do some thing here will run every time server loaded
+
+          return sub  {
+                # the real app code here
+          }
+  };
+
+  my $runner = Plack::Runner->new;
+  $runner->parse_options(@ARGV);
+  $runner->run(\$app_builder); # use code ref ref
 
 =head1 DESCRIPTION
 

--- a/t/Plack-Runner/app_builder.t
+++ b/t/Plack-Runner/app_builder.t
@@ -1,0 +1,80 @@
+use Test::More;
+use Plack::Runner;
+use File::Path (qw/make_path remove_tree/);
+use Test::Requires 'LWP::UserAgent';
+
+make_path "tmp/m";
+
+sub app_builder {
+    eval {
+        open my $fh, ">>", "tmp/counter";
+        print $fh "1";
+        close $fh;
+    };
+    sub {
+         return [ 200, [], [ "Hello" ] ]
+    }
+}
+
+my $runner = Plack::Runner->new;
+
+sub counter_ok {
+    my ($len, $msg) = @_;
+    my $content = "";
+    eval {
+        open my $fh, "<", "tmp/counter";
+        $content = <$fh>;
+
+    };
+    is $content ,"1" x $len, $msg;
+}
+
+$runner->parse_options( -R => 'tmp/m' , '-r' , -p => 5000 );
+
+my $pid = fork;
+
+if ($pid) {
+    my $timeout = 5;
+    until (-f "tmp/counter") {
+        sleep 1;
+        last if $timeout-- == 0;
+    }
+    if ($timeout < 0) {
+        is 1 < 0 , "plack up server failed";
+        kill 'TERM' => $pid;
+    }else {
+        my $ua = LWP::UserAgent->new;
+        my $res = $ua->get('http://127.0.0.1:5000/');
+        ok $res->is_success;
+        is $res->code, 200;
+        is $res->content, 'Hello';
+
+        counter_ok 1, "app builder not run";
+
+        make_path "tmp/m/a";
+        sleep 1;
+
+        counter_ok 2, "app builder run";
+        $res = $ua->get('http://127.0.0.1:5000/');
+        ok $res->is_success;
+        is $res->code, 200;
+        is $res->content, 'Hello';
+
+        remove_tree "tmp/m/a";
+        sleep 1;
+
+        counter_ok 3, "app builder run again";
+
+        kill 'TERM' => $pid;
+    }
+}else {
+    $runner->run(\\&app_builder);
+    exit 0;
+}
+
+remove_tree "tmp";
+done_testing;
+
+
+
+


### PR DESCRIPTION
when I use `Plack::Runner` to plackup pice of code to run, i found it can not supply some code ran at each time of the server was loaded (especially reloaded), for exmaple : 

```
package Te::Myblog;
#use HiD; # is a static blog builder
use Plack::Runner;

my $hid = $self->build_hid;
my $app = sub {
     $hid->rebuild;
     return  Plack::App::File->new(root => $self->destination )->to_app;
};

my $runner = Plack::Runner->new;
$runner->parse_options('-r', '-R' => $self->source_dir);
$runner->run($app);
```

then, the plack server will restart when it found the directory 's file changed;
when the server restart, I hope I can do some work incidentally ， here is rebuild the blog；

I found the `Plack::Runner::locate_app` method will treat code ref of app as : 

(https://github.com/plack/Plack/blob/master/lib/Plack/Runner.pm#L160)

```
 if (ref $psgi eq 'CODE') {
    return sub { $psgi };
}
```

so, I append a pice of code, to satisfy my requirement

hopen you can merge it to your wonderful code. that's great for everyone to use it :)

Very thanks !
