### PR TITLE
set no_proxy for LWPish

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -14,7 +14,7 @@ requires 'Try::Tiny';
 requires 'URI', '1.59';
 requires 'parent';
 requires 'Apache::LogFormat::Compiler', '0.12';
-requires 'HTTP::Tiny', 0.024;
+requires 'HTTP::Tiny', 0.034;
 
 on test => sub {
     requires 'Test::More', '0.88';

--- a/lib/Plack/Test/Server.pm
+++ b/lib/Plack/Test/Server.pm
@@ -13,7 +13,7 @@ sub test_psgi {
 
     my $client = delete $args{client} or croak "client test code needed";
     my $app    = delete $args{app}    or croak "app needed";
-    my $ua     = delete $args{ua} || Plack::LWPish->new;
+    my $ua     = delete $args{ua} || Plack::LWPish->new( no_proxy => [qw/127.0.0.1/] );
 
     test_tcp(
         client => sub {

--- a/lib/Plack/Test/Suite.pm
+++ b/lib/Plack/Test/Suite.pm
@@ -754,8 +754,7 @@ sub run_server_tests {
     test_tcp(
         client => sub {
             my $port = shift;
-
-            my $ua = Plack::LWPish->new;
+            my $ua = Plack::LWPish->new( no_proxy => [qw/127.0.0.1/] );
             for my $i (0..$#TEST) {
                 my $test = $TEST[$i];
                 note $test->[0];


### PR DESCRIPTION
Sets no_proxy for LWPish

HTTP::Tiny (LWPish used) automatically uses $ENV{http_proxy} if exists. 
So t/Plack-Handler/standalone.t and t/Plack-Loader/shotgun.t fail if $ENV{http_proxy} exists.
