### PR TITLE
Plack::Middleware::LogDispatch now stringifies objects.

### DIFF
--- a/lib/Plack/Middleware/LogDispatch.pm
+++ b/lib/Plack/Middleware/LogDispatch.pm
@@ -17,6 +17,11 @@ sub call {
     $env->{'psgix.logger'} = sub {
         my $args = shift;
         $args->{level} = 'critical' if $args->{level} eq 'fatal';
+
+        if ( ref $args->{message} && ref $args->{message} ne 'CODE' ) {
+            $args->{message} .= q{};
+        }
+
         $self->logger->log(%$args);
     };
 

--- a/t/Plack-Middleware/log_dispatch.t
+++ b/t/Plack-Middleware/log_dispatch.t
@@ -8,6 +8,12 @@ use HTTP::Request::Common;
 use Log::Dispatch;
 use Log::Dispatch::Array;
 
+package Stringify;
+use overload q{""} => sub { 'stringified object' };
+sub new { bless {}, shift }
+
+package main;
+
 my @logs;
 
 my $logger = Log::Dispatch->new;
@@ -19,6 +25,9 @@ $logger->add(Log::Dispatch::Array->new(
 my $app = sub {
     my $env = shift;
     $env->{'psgix.logger'}->({ level => "debug", message => "This is debug" });
+    $env->{'psgix.logger'}->({ level => "info", message => sub { 'code ref' } });
+    $env->{'psgix.logger'}->({ level => "notice", message => Stringify->new() });
+
     return [ 200, [], [] ];
 };
 
@@ -28,9 +37,15 @@ test_psgi $app, sub {
     my $cb = shift;
     my $res = $cb->(GET "/");
 
-    is @logs, 1;
+    is @logs, 3;
     is $logs[0]->{level}, 'debug';
     is $logs[0]->{message}, 'This is debug';
+
+    is $logs[1]->{level}, 'info';
+    is $logs[1]->{message}, 'code ref';
+
+    is $logs[2]->{level}, 'notice';
+    is $logs[2]->{message}, 'stringified object';
 };
 
 done_testing;


### PR DESCRIPTION
This is something I poached from @autarch.  If you're passing (for
instance) a Throwable exception to Log::Dispatch it will _not_ stringify
the exception for you.  This patch handles this case and also adds a
test to make sure that code refs are not stringified, since
Log::Dispatch does accept those as valid messages.
