### PR TITLE
PM::ErrorDocument: removing Content-Encoding and Transfer-Encoding. 

### DIFF
--- a/lib/Plack/Middleware/ErrorDocument.pm
+++ b/lib/Plack/Middleware/ErrorDocument.pm
@@ -61,6 +61,8 @@ sub call {
         } else {
             my $h = Plack::Util::headers($r->[1]);
             $h->remove('Content-Length');
+            $h->remove('Content-Encoding');
+            $h->remove('Transfer-Encoding');
             $h->set('Content-Type', Plack::MIME->mime_type($path));
 
             open my $fh, "<", $path or die "$path: $!";


### PR DESCRIPTION
If original response has `Content-Encoding: gzip` or `Transfer-Encoding: chunked` header, 
the error-document will be decoding error in HTTP client.
