### PR TITLE
Optimize Plack::Response->finalize

### DIFF
--- a/lib/Plack/Response.pm
+++ b/lib/Plack/Response.pm
@@ -85,24 +85,20 @@ sub finalize {
     my $self = shift;
     Carp::croak "missing status" unless $self->status();
 
-    my $headers = $self->headers->clone;
-    $self->_finalize_cookies($headers);
+    my $headers = $self->headers;
+    my @headers;
+    $headers->scan(sub{
+        my ($k,$v) = @_;
+        $v =~ s/\015\012[\040|\011]+/chr(32)/ge; # replace LWS with a single SP
+        $v =~ s/\015|\012//g; # remove CR and LF since the char is invalid here
+        push @headers, $k, $v;
+    });
+
+    $self->_finalize_cookies(\@headers);
 
     return [
         $self->status,
-        +[
-            map {
-                my $k = $_;
-                map {
-                    my $v = $_;
-                    $v =~ s/\015\012[\040|\011]+/chr(32)/ge; # replace LWS with a single SP
-                    $v =~ s/\015|\012//g; # remove CR and LF since the char is invalid here
-
-                    ( $k => $v )
-                } $headers->header($_);
-
-            } $headers->header_field_names
-        ],
+        \@headers,
         $self->_body,
     ];
 }
@@ -129,7 +125,7 @@ sub _finalize_cookies {
 
     while (my($name, $val) = each %{$self->cookies}) {
         my $cookie = $self->_bake_cookie($name, $val);
-        $headers->push_header('Set-Cookie' => $cookie);
+        push @$headers, 'Set-Cookie' => $cookie;
     }
 }
 


### PR DESCRIPTION
- use HTTP::Headers->scan to build a headers arrray
- pass this array to _finalize_cookie
- HTTP::Headers->clone becomes unnecessary

This patch makes 2x faster for finalize response.
benchmark code is here. https://gist.github.com/kazeburo/7093522
