### PR TITLE
make HTTP::Message::PSGI complain loudly about invalid PSGI responses

### DIFF
--- a/lib/HTTP/Message/PSGI.pm
+++ b/lib/HTTP/Message/PSGI.pm
@@ -105,6 +105,10 @@ sub res_from_psgi {
             _res_from_psgi($_[0], \$res);
         });
     }
+    else {
+        my $response = defined $psgi_res ? "'$psgi_res'" : 'undef';
+        die "Bad response $response";
+    }
 
     return $res;
 }

--- a/t/HTTP-Message-PSGI/unknown_response.t
+++ b/t/HTTP-Message-PSGI/unknown_response.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More;
+use HTTP::Message::PSGI;
+use HTTP::Request;
+use HTTP::Response;
+
+my $res;
+my $app = sub { $res };
+my $env = req_to_psgi(HTTP::Request->new(GET => "http://localhost/"));
+
+eval { HTTP::Response->from_psgi($app->($env)) };
+like($@, qr/Bad response undef/, 'converting undef PSGI response results in error');
+
+$res = 5;
+
+eval { HTTP::Response->from_psgi($app->($env)) };
+like($@, qr/Bad response '5'/, 'converting invalid PSGI response results in error');
+
+done_testing;


### PR DESCRIPTION
Without this, HTTP::Message::PSGI will silently suppress invalid responses, leading to confusing error messages from inside Plack::Test::MockHTTP.
