### PR TITLE
Show original stacktraces for rethrown exceptions

### DIFF
--- a/lib/Plack/Middleware/StackTrace.pm
+++ b/lib/Plack/Middleware/StackTrace.pm
@@ -42,7 +42,7 @@ sub call {
         [ 500, [ "Content-Type", "text/plain; charset=utf-8" ], [ no_trace_error(utf8_safe($caught)) ] ];
     };
 
-    if ($trace && ($caught || ($self->force && ref $res eq 'ARRAY' && $res->[0] == 500)) ) {
+    if ($trace && ($caught ? (_make_key($caught) eq $last_key) : ($self->force && ref $res eq 'ARRAY' && $res->[0] == 500)) ) {
         my $text = $trace->as_string;
         my $html = $trace->as_html;
         $env->{'plack.stacktrace.text'} = $text;

--- a/lib/Plack/Middleware/StackTrace.pm
+++ b/lib/Plack/Middleware/StackTrace.pm
@@ -19,16 +19,18 @@ sub call {
     my($self, $env) = @_;
 
     my $trace;
-    my %seen;
+    my $last_key = '';
     local $SIG{__DIE__} = sub {
         my $key = _make_key($_[0]);
-        if (!$seen{$key}) {
+        # If we get the same keys, the exception may be rethrown and
+        # we keep the original stacktrace.
+        if ($key ne $last_key) {
             $trace = $StackTraceClass->new(
                 indent => 1, message => munge_error($_[0], [ caller ]),
                 ignore_package => __PACKAGE__,
             );
+            $last_key = $key;
         }
-        $seen{$key} = 1;
         die @_;
     };
 

--- a/lib/Plack/Middleware/StackTrace.pm
+++ b/lib/Plack/Middleware/StackTrace.pm
@@ -42,7 +42,7 @@ sub call {
         [ 500, [ "Content-Type", "text/plain; charset=utf-8" ], [ no_trace_error(utf8_safe($caught)) ] ];
     };
 
-    if ($trace && ($caught ? (_make_key($caught) eq $last_key) : ($self->force && ref $res eq 'ARRAY' && $res->[0] == 500)) ) {
+    if ($trace && $self->should_show_trace($caught, $last_key, $res)) {
         my $text = $trace->as_string;
         my $html = $trace->as_html;
         $env->{'plack.stacktrace.text'} = $text;
@@ -61,6 +61,15 @@ sub call {
     undef $trace;
 
     return $res;
+}
+
+sub should_show_trace {
+    my ($self, $err, $key, $res) = @_;
+    if ($err) {
+        return _make_key($err) eq $key;
+    } else {
+        return $self->force && ref $res eq 'ARRAY' && $res->[0] == 500;
+    }
 }
 
 sub no_trace_error {

--- a/t/Plack-Middleware/stacktrace/rethrow.t
+++ b/t/Plack-Middleware/stacktrace/rethrow.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use Test::More;
+use Plack::Middleware::StackTrace;
+use Plack::Test;
+use HTTP::Request::Common;
+
+$Plack::Test::Impl = "Server";
+local $ENV{PLACK_SERVER} = "HTTP::Server::PSGI";
+
+my $app = sub {
+    eval { challenge() };
+    die $@ if $@;
+};
+
+sub challenge {
+    die "oops";
+}
+
+my $wrapped = Plack::Middleware::StackTrace->wrap($app, no_print_errors => 1);
+
+test_psgi $wrapped, sub {
+    my $cb = shift;
+
+    my $req = GET "/";
+    my $res = $cb->($req);
+
+    is $res->code, 500;
+    like $res->content, qr/main::challenge/;
+};
+
+done_testing;
+

--- a/t/Plack-Middleware/stacktrace/sigdie.t
+++ b/t/Plack-Middleware/stacktrace/sigdie.t
@@ -25,5 +25,23 @@ test_psgi $wrapped, sub {
     like $res->content, qr/The application raised/;
 };
 
+my $twice_died_app = sub {
+    eval { die "hmm" };
+    $SIG{__DIE__} = sub {};
+    die "meh";
+};
+
+my $twice_died_wrapped = Plack::Middleware::StackTrace->wrap($twice_died_app, no_print_errors => 1);
+
+test_psgi $twice_died_wrapped, sub {
+    my $cb = shift;
+
+    my $req = GET "/";
+    my $res = $cb->($req);
+
+    is $res->code, 500;
+    like $res->content, qr/The application raised/;
+};
+
 done_testing;
 


### PR DESCRIPTION
It's good if Plack::Middleware::StackTrace can handle stacktraces for rethrown exceptions as developers expect.

This is a successor of https://github.com/plack/Plack/compare/original-stacktrace reducing "false cache hit".
