### PR TITLE
let an http-exception object that ->can("as_psgi") recieve the psgi $env...

### DIFF
--- a/lib/Plack/Middleware/HTTPExceptions.pm
+++ b/lib/Plack/Middleware/HTTPExceptions.pm
@@ -31,14 +31,16 @@ sub call {
         try {
             $response->(sub { return $writer = $responder->(@_) });
         } catch {
-            if ($writer) {
-                Carp::cluck $_;
-                $writer->close;
-            } else {
-                my $error_psgi_response = $self->transform_error($_, $env);
-                return $responder->($error_psgi_response) if ref $error_psgi_response eq 'ARRAY';
-                return $unroll_coderef_responses->($responder, $error_psgi_response);
-            }
+          if($writer) {
+              # In the case where the exception happens part way through a write
+              # We just die since we can't at this point change the response
+              Carp::cluck $_;
+              $writer->close;
+          } else {
+            my $error_psgi_response = $self->transform_error($_, $env);
+            return $responder->($error_psgi_response) if ref $error_psgi_response eq 'ARRAY';
+            return $unroll_coderef_responses->($responder, $error_psgi_response);
+          }
         };
     };
 
@@ -149,6 +151,29 @@ for this middleware, and the exception will instead be rethrown. This is
 enabled by default when C<PLACK_ENV> is set to C<development>, so that
 the L<StackTrace|Plack::Middleware::StackTrace> middleware can catch it
 instead.
+
+=head1 NOTES
+
+In the case where an exception rises during the middle of a streaming
+response (such as the following):
+
+    my $psgi_app = sub {
+    my $env = shift;
+        return sub {
+        my $responder = shift;
+        my $writer = $responder->([200, ['content-type'=>'text/html']]);
+        $writer->write('ok');
+
+        # Stuff...
+
+        die MyApp::Exception::ServerError->new($env);
+    };
+
+We can't meaningfully set the response from this exception, since at this
+point HTTP Headers and a partial body have been returned.  If you need to
+verify such a case you'll need to rely on alternative means, such as setting
+expected content-length or providing a checksum, that the client can use to
+valid the returned content.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
... as its first argument

The idea here is that if the exception object is doing its own as_psgi, it might which to have access to $env so as to perform some content negotiation and provide the acceptable body content.  Or for any other reasons.  I don't think this change will cause any issues:

https://metacpan.org/pod/HTTP::Throwable#as_psgi

Says will accept $env but currently that is not used, so this change will work into the expectation I think.

HTTP::Exception  does not have the as_psgi method so there's no compatibility problems.

I realized that the code that throws the exception object will also have $env and it is assumed that one could also do some content negotiation/etc there as well, but I think this change would make it easier for anyone working on a general framework to set some sane defaults.

code/test case/doc patch all included.
