### PR TITLE
POSIX::setlocale fails on system without locales (Android)

### DIFF
--- a/lib/Plack/Middleware/SimpleLogger.pm
+++ b/lib/Plack/Middleware/SimpleLogger.pm
@@ -1,6 +1,7 @@
 package Plack::Middleware::SimpleLogger;
 use strict;
 use parent qw(Plack::Middleware);
+use Config ();
 use Plack::Util::Accessor qw(level);
 use POSIX ();
 use Scalar::Util ();
@@ -29,10 +30,15 @@ sub call {
 }
 
 sub format_time {
-    my $old_locale = eval { POSIX::setlocale(&POSIX::LC_ALL) };
-    eval { POSIX::setlocale(&POSIX::LC_ALL, 'C') };
+    my $old_locale;
+    if ( $Config::config{d_setlocale} ) {
+        $old_locale = POSIX::setlocale(&POSIX::LC_ALL);
+        POSIX::setlocale(&POSIX::LC_ALL, 'C');
+    }
     my $out = POSIX::strftime(@_);
-    eval { POSIX::setlocale(&POSIX::LC_ALL, $old_locale) };
+    if ( $Config::config{d_setlocale} ) {
+        POSIX::setlocale(&POSIX::LC_ALL, $old_locale);
+    };
     return $out;
 }
 


### PR DESCRIPTION
I'm getting an error on Android. This system has poor support for locales, so the Perl is usually compiled with -Ui_locale flag.

```
t/Plack-Middleware/simple_logger.t ................. 1/? 
#   Failed test at t/Plack-Middleware/simple_logger.t line 24.
#                   'Your vendor has not defined POSIX macro LC_ALL, used at /storage/sdcard0/home/.cpanm/work/1389472371.9142/Plack-1.0030/blib/lib/Plack/Middleware/SimpleLogger.pm line 32
# '
#     doesn't match '(?^:This is info)'
# Looks like you failed 1 test of 2.
t/Plack-Middleware/simple_logger.t ................. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/2 subtests 
```

It is built cleanly with this patch.

Unfortunately, Plack still doesn't work well on Android because there is some other problem which test units didn't detect:

```
$ plackup -e 'sub {[200, [$^O], []]}' -E test
Use of uninitialized value $v in concatenation (.) or string at /data/perl/lib/site_perl/5.18.2/HTTP/Server/PSGI.pm line 204.
```

returns

```
$ telnet htc-one-s 5000
Trying 192.168.1.84...
Connected to htc-one-s.
Escape character is '^]'.
GET / HTTP/1.0

HTTP/1.0 200 OK
Date: Sat, 11 Jan 2014 21:05:53 GMT
Server: HTTP::Server::PSGI
linux: Content-Length
0: 

Connection closed by foreign host.
```

I'll provide proper patch if I track this problem.
