### PR TITLE
parse query_string like "?foo+bar" into { "foo bar" => "" }

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -85,18 +85,10 @@ sub _parse_query {
     my @query;
     my $query_string = $self->env->{QUERY_STRING};
     if (defined $query_string) {
-        if ($query_string =~ /=/) {
-            # Handle  ?foo=bar&bar=foo type of query
-            @query =
-                map { s/\+/ /g; URI::Escape::uri_unescape($_) }
-                map { /=/ ? split(/=/, $_, 2) : ($_ => '')}
-                split(/[&;]/, $query_string);
-        } else {
-            # Handle ...?dog+bones type of query
-            @query =
-                map { (URI::Escape::uri_unescape($_), '') }
-                split(/\+/, $query_string, -1);
-        }
+        @query =
+            map { s/\+/ /g; URI::Escape::uri_unescape($_) }
+            map { /=/ ? split(/=/, $_, 2) : ($_ => '')}
+            split(/[&;]/, $query_string);
     }
 
     Hash::MultiValue->new(@query);

--- a/t/Plack-Request/uri.t
+++ b/t/Plack-Request/uri.t
@@ -82,6 +82,13 @@ my @tests = (
     { add_env => {
         HTTP_HOST => 'example.com',
         SCRIPT_NAME => "",
+        QUERY_STRING => "foo+bar"
+      },
+      uri => 'http://example.com/?foo+bar',
+      parameters => { 'foo bar' => '' } },
+    { add_env => {
+        HTTP_HOST => 'example.com',
+        SCRIPT_NAME => "",
         QUERY_STRING => 0
       },
       uri => 'http://example.com/?0',


### PR DESCRIPTION
Current Plack::Request parses query_string like `?foo+bar` query into `{ foo => "", bar => ""}`.
But this behavior is not popular. Mojo::Parameter, ruby's Rack, python's WebOb and node.js will parse that query_string into `{ "foo bar" => "" }`

In addition, CGI specifications splits query_string that does not contain "=" by "+" and treats as command line arguments. Behavior of cunnrent Plack::Request query_string parser does not match with the specifications of the CGI.
