### PR TITLE
fix small pod escape typo

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -451,7 +451,7 @@ strings that are sent by clients and are URI decoded.
 If there are multiple cookies with the same name in the request, this
 method will ignore the duplicates and return only the first value. If
 that causes issues for you, you may have to use modules like
-CGI::Simple::Cookie to parse C<$request->header('Cookies')> by
+CGI::Simple::Cookie to parse C<<$request->header('Cookies')>> by
 yourself.
 
 =item query_parameters


### PR DESCRIPTION
Happen to come across it while reading docs.
