### PR TITLE
Add the ability of hiding server information. =>

### DIFF
--- a/lib/HTTP/Server/PSGI.pm
+++ b/lib/HTTP/Server/PSGI.pm
@@ -39,6 +39,7 @@ sub new {
         port               => $args{port} || 8080,
         timeout            => $args{timeout} || 300,
         server_software    => $args{server_software} || $class,
+        no_server_tokens   => $args{no_server_tokens} || 0,
         server_ready       => $args{server_ready} || sub {},
         ssl                => $args{ssl},
         ipv6               => $args{ipv6},
@@ -196,8 +197,10 @@ sub _handle_response {
 
     my @lines = (
         "Date: @{[HTTP::Date::time2str()]}\015\012",
-        "Server: $self->{server_software}\015\012",
     );
+
+    $self->{no_server_tokens}
+        or push @lines, "Server: $self->{server_software}\015\012";
 
     Plack::Util::header_iter($res->[1], sub {
         my ($k, $v) = @_;


### PR DESCRIPTION
There are some deployment environments that consider the leakage of software
  type and/or version to be a security risk. This commit addresses the issue
  by allowing an extra parameter to be passed to the server's constructor to
  determine whether to add the "Server" header in the response (which we are
  currently adding "obligatorily").

The issue was spawned by the "Dancer2" web framework -- a user of ours -- not
  being able to hide the server's identity in their development environment
  (in which we are the web server).
