### PR TITLE
Add caller_depth arg

### DIFF
--- a/lib/Plack/Middleware/Log4perl.pm
+++ b/lib/Plack/Middleware/Log4perl.pm
@@ -21,8 +21,9 @@ sub call {
     $env->{'psgix.logger'} = sub {
         my $args = shift;
         my $level = $args->{level};
+        my $caller_depth = $args->{caller_depth} || 0 ;
         local $Log::Log4perl::caller_depth
-            = $Log::Log4perl::caller_depth + 1;
+            = $Log::Log4perl::caller_depth + 1 + $caller_depth;
         $self->logger->$level($args->{message});
     };
 


### PR DESCRIPTION
Adds an optional argument <tt>caller_depth</tt> to the <tt>psgix.logger</tt> anonymous sub so that callers can add additional layers of <tt>caller_depth</tt> to Log4perl output that is using <tt>Plack::Middleware::Log4perl</tt> PatternLayout config values which include the file or line number (like %F, %l and %L).

Without the ability to have the caller additionally adjust the caller depth, a <tt>psgix.logger</tt> using Log4perl always shows the immediate caller and not (necessarily) the "original" caller.

For example, when using <tt>Dancer::Logger::PSGI</tt>, the Dancer logging keywords have three additional calling layers so the %F, %l and %L placeholders point to <tt>Dancer/Logger/PSGI.pm</tt> instead of the "original" caller.

Originally I addressed this problem by using <tt>local</tt> and adjusting <tt>$Log::Log4perl::caller_depth</tt> in <tt>Dancer::Logger::PSGI</tt> which works. However, because <tt>psgix.logger</tt> is an anonymous sub, the caller to <tt>psgix.logger</tt> (<tt>Dancer::Logger::PSGI</tt> in this case) doesn't doesn't know whether the currently configured Plack logger is Log4perl or something else (like Log::Dispatch) and therefore whether <tt>$Log::Log4perl::caller_depth</tt> is even available.

Of course, to get this all to work <tt>Dancer::Logger::PSGI</tt> would also have to be modified to set the <tt>caller_depth</tt> argument when calling <tt>psgix.logger</tt>.

Perhaps there is a cleaner way to address this problem? <tt>Dancer::Logger::PSGI</tt> could just check whether <tt>Logger::Log4perl</tt> is loaded and set <tt>$Log::Log4perl::caller_depth</tt> only in that case.
