### PR TITLE
Fix content filter in ErrorDocument

### DIFF
--- a/lib/Plack/Middleware/ErrorDocument.pm
+++ b/lib/Plack/Middleware/ErrorDocument.pm
@@ -72,9 +72,9 @@ sub call {
                 my $done;
                 return sub {
                     unless ($done) {
+                        $done = 1;
                         return join '', <$fh>;
                     }
-                    $done = 1;
                     return defined $_[0] ? '' : undef;
                 };
             };


### PR DESCRIPTION
The content filter in ErrorDocument never set the $done variable to a
true value in the non-subrequest case. As a result, it kept returning
empty strings at the end of input, not undef like it should. This is
actually harmless because response_cb copes with this behavior.
