### PR TITLE
Make return of response_cb explicit rather than implicit.

### DIFF
--- a/lib/Plack/Middleware.pm
+++ b/lib/Plack/Middleware.pm
@@ -100,11 +100,16 @@ is pointless, so you're recommended to use the C<response_cb> wrapper
 function in L<Plack::Util> when implementing a post processing
 middleware.
 
-  my $res = $app->($env);
-  Plack::Util::response_cb($res, sub {
-      my $res = shift;
-      # do something with $res;
-  });
+  sub call {
+      my($self, $env) = @_;
+      # pre-processing $env
+      my $res = $app->($env);
+
+      return Plack::Util::response_cb($res, sub {
+          my $res = shift;
+          # do something with $res;
+      });
+  }
 
 The callback function gets a response as an array reference, and you can
 update the reference to implement the post-processing. In the normal
@@ -119,7 +124,7 @@ described below.
   sub call {
       my($self, $env) = @_;
       my $res  = $self->app->($env);
-      Plack::Util::response_cb($res, sub {
+      return Plack::Util::response_cb($res, sub {
           my $res = shift;
           $res->[0] = 500;
           return;


### PR DESCRIPTION
This bit me earlier this week when I wasn't paying enough attention and
included some logic in my call() method _after_ calling response_cb().

There are other explicit returns in the code samples here.  I think it
wouldn't hurt to make it obvious that response_cb()'s return value needs
to be returned by the Middleware.
