### PR TITLE
Skip tests requiring fork() when no fork() is available

### DIFF
--- a/t/HTTP-Server-PSGI/harakiri.t
+++ b/t/HTTP-Server-PSGI/harakiri.t
@@ -1,10 +1,17 @@
 use strict;
 use warnings;
 
+use Config;
 use Plack::Runner;
 use Test::More;
 use Test::TCP;
 use Test::Requires qw(LWP::UserAgent);
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 my $ua_timeout = 3;
 

--- a/t/HTTP-Server-PSGI/post.t
+++ b/t/HTTP-Server-PSGI/post.t
@@ -1,10 +1,17 @@
 use strict;
 use warnings;
 
+use Config;
 use Plack::Runner;
 use Test::More;
 use Test::TCP;
 use Test::Requires qw(LWP::UserAgent);
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 test_tcp(
     server => sub {

--- a/t/Plack-Handler/standalone.t
+++ b/t/Plack-Handler/standalone.t
@@ -1,7 +1,14 @@
 use strict;
 use warnings;
+use Config;
 use Test::More;
 use Plack::Test::Suite;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 Plack::Test::Suite->run_server_tests('Standalone');
 done_testing();

--- a/t/Plack-Middleware/component-leak.t
+++ b/t/Plack-Middleware/component-leak.t
@@ -1,9 +1,16 @@
 package MyComponent;
 use strict;
 use warnings;
+use Config;
 use Test::More;
 use Scalar::Util qw/weaken/;
 use parent 'Plack::Component';
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 sub call {
     my $self = shift;

--- a/t/Plack-Middleware/error_document_streaming_app.t
+++ b/t/Plack-Middleware/error_document_streaming_app.t
@@ -1,10 +1,17 @@
 use strict;
 use warnings;
+use Config;
 use FindBin;
 use Test::More;
 use HTTP::Request::Common;
 use Plack::Test;
 use Plack::Builder;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 $Plack::Test::Impl = undef;
 my @impl = ('Server', 'MockHTTP');

--- a/t/Plack-Middleware/stacktrace/sigdie.t
+++ b/t/Plack-Middleware/stacktrace/sigdie.t
@@ -1,9 +1,16 @@
 use strict;
 use warnings;
+use Config;
 use Test::More;
 use Plack::Middleware::StackTrace;
 use Plack::Test;
 use HTTP::Request::Common;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 $Plack::Test::Impl = "Server";
 local $ENV{PLACK_SERVER} = "HTTP::Server::PSGI";

--- a/t/Plack-Middleware/stacktrace/utf8.t
+++ b/t/Plack-Middleware/stacktrace/utf8.t
@@ -1,10 +1,17 @@
 use strict;
 use warnings;
+use Config;
 use Test::More;
 use Test::Requires { 'Devel::StackTrace::AsHTML' => 0.08 };
 use Plack::Middleware::StackTrace;
 use Plack::Test;
 use HTTP::Request::Common;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 $Plack::Test::Impl = "Server";
 local $ENV{PLACK_SERVER} = "HTTP::Server::PSGI";

--- a/t/Plack-Middleware/urlmap_ports.t
+++ b/t/Plack-Middleware/urlmap_ports.t
@@ -1,8 +1,15 @@
 use strict;
+use Config;
 use Test::More;
 use Plack::App::URLMap;
 use Plack::Test;
 use HTTP::Request::Common;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 $Plack::Test::Impl = "Server";
 local $ENV{PLACK_SERVER} = "HTTP::Server::PSGI";

--- a/t/Plack-Request/double_port.t
+++ b/t/Plack-Request/double_port.t
@@ -1,7 +1,14 @@
+use Config;
 use Test::More;
 use Plack::Test;
 use Plack::Request;
 use HTTP::Request::Common;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 $Plack::Test::Impl = 'Server';
 local $ENV{PLACK_SERVER} = "HTTP::Server::PSGI";

--- a/t/Plack-Request/upload-large.t
+++ b/t/Plack-Request/upload-large.t
@@ -1,9 +1,16 @@
 use strict;
 use warnings;
+use Config;
 use Test::More;
 use Plack::Request;
 use Plack::Test;
 use HTTP::Request::Common;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 my $file = "share/baybridge.jpg";
 

--- a/t/Plack-Test/2args.t
+++ b/t/Plack-Test/2args.t
@@ -1,6 +1,14 @@
+use Config;
 use Plack::Test;
 use Test::More;
 use HTTP::Request::Common;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
 $Plack::Test::Impl = "Server";
 local $ENV{PLACK_SERVER} = "HTTP::Server::PSGI";
 

--- a/t/Plack-Test/hello_server.t
+++ b/t/Plack-Test/hello_server.t
@@ -1,5 +1,12 @@
+use Config;
 use Test::More;
 use Plack::Test;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 $Plack::Test::Impl = "Server";
 local $ENV{PLACK_SERVER} = "HTTP::Server::PSGI";

--- a/t/Plack-Util/response_cb.t
+++ b/t/Plack-Util/response_cb.t
@@ -1,9 +1,16 @@
 use strict;
 use warnings;
+use Config;
 use Plack::Util;
 use Plack::Test;
 use Test::More;
 use HTTP::Request::Common;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 $Plack::Test::Impl = "Server";
 


### PR DESCRIPTION
If you build perl on Windows without -DPERL_IMPLICIT_SYS (which I do, in
order to enable -DPEL_MALLOC, which seems faster than using the system
malloc()) then you don't get the fork() emulation and several of Plack's
tests fail.

This commit skips those tests in the same manner as various other CPAN
modules do in this case. This allows a normal "cpan install ..." of
Plack or anything depending on it (e.g. Dancer) to succeed without having
to "force" anything.
