### PR TITLE
Speed improvements for big uploads

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -268,18 +268,20 @@ sub _parse_request_body {
         $buffer = Stream::Buffered->new($cl);
     }
 
-    my $spin = 0;
+    my $spin    = 0;
+    my $content = '';
     while ($cl) {
         $input->read(my $chunk, $cl < 8192 ? $cl : 8192);
         my $read = length $chunk;
         $cl -= $read;
-        $body->add($chunk);
+        $content .= $chunk;
         $buffer->print($chunk) if $buffer;
 
         if ($read == 0 && $spin++ > 2000) {
             Carp::croak "Bad Content-Length: maybe client disconnect? ($cl bytes remaining)";
         }
     }
+    $body->add($content);
 
     if ($buffer) {
         $self->env->{'psgix.input.buffered'} = 1;


### PR DESCRIPTION
This originated as PerlDancer/Dancer GH [#1092](https://github.com/PerlDancer/Dancer/pull/1092), work by Rick Myers.

I have ported this to Dancer2 and I think it makes sense to have it
in Plack::Request too.

Basically instead of adding to the body every time we read a chunk,
we just add them to a variable and then, once done, we feed the
body with the entire content.

This isn't done for the streamed buffer because that actually calls
"print" on the buffer, so I'm assuming it might write somewhere the
chunked content, so that might break (expected) behavior.

Also, perhaps it's better to set the entire body instead of "add"
method, but when I tried it, a bunch of tests failed and I didn't
look into why.
