### PR TITLE
call $body->add() outside of loop for speed

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -269,17 +269,19 @@ sub _parse_request_body {
     }
 
     my $spin = 0;
+    my $content;
     while ($cl) {
         $input->read(my $chunk, $cl < 8192 ? $cl : 8192);
         my $read = length $chunk;
         $cl -= $read;
-        $body->add($chunk);
-        $buffer->print($chunk) if $buffer;
+        $content .= $chunk;
 
         if ($read == 0 && $spin++ > 2000) {
             Carp::croak "Bad Content-Length: maybe client disconnect? ($cl bytes remaining)";
         }
     }
+    $body->add($content);
+    $buffer->print($content) if $buffer;
 
     if ($buffer) {
         $self->env->{'psgix.input.buffered'} = 1;


### PR DESCRIPTION
Follow-up on PerlDancer/Dancer#1092

For the Dancer ticket, the root cause for the
performance problem ended being with HTTP::Body, but
it seems there is still a small gain to be had by
calling '->add()' outside of the loop (which makes
sense for huge files).

The question is, should I add a performance test
to characterize exactly how much we're gaining with
this patch, or is it good (or not) as-is?
