### PR TITLE
improve document: use 'PSGI servers' instead of 'Plack servers'

### DIFF
--- a/script/plackup
+++ b/script/plackup
@@ -10,7 +10,7 @@ __END__
 
 =head1 NAME
 
-plackup - Run PSGI application with Plack servers
+plackup - Run PSGI application with PSGI servers
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
By definition,

> "Plack is a set of PSGI utilities and contains the reference PSGI server HTTP::Server::PSGI"

http://search.cpan.org/~miyagawa/PSGI-1.102/PSGI/FAQ.pod#Plack

The word "Plack servers" is not defined and the meaning can be ambiguous. 
(multi process of  HTTP::Server::PSGI , or PSGI servers in general ?)
