### PR TITLE
Allow Handler::FCGI to run non-forked

### DIFF
--- a/lib/Plack/Handler/FCGI.pm
+++ b/lib/Plack/Handler/FCGI.pm
@@ -110,7 +110,7 @@ sub run {
             'psgi.errors'       => 
                 ($self->{keep_stderr} ? \*STDERR : $self->{stderr}),
             'psgi.multithread'  => Plack::Util::FALSE,
-            'psgi.multiprocess' => Plack::Util::TRUE,
+            'psgi.multiprocess' => defined $proc_manager,
             'psgi.run_once'     => Plack::Util::FALSE,
             'psgi.streaming'    => Plack::Util::TRUE,
             'psgi.nonblocking'  => Plack::Util::FALSE,
@@ -275,6 +275,7 @@ Specify a filename for the pid file
 =item manager
 
 Specify either a FCGI::ProcManager subclass, or an actual FCGI::ProcManager-compatible object.
+If you do not want a FCGI::ProcManager but instead run in a single process, set this to undef.
 
   use FCGI::ProcManager::Dynamic;
   Plack::Handler::FCGI->new(


### PR DESCRIPTION
Motivation:

To be able to easily debug a FastCGI Plack application from Eclipse (EPIC) I want it to make it run without spawning worker processes, but run within a single process, as EPIC does not support a debug session to a forked child.

Modifications:

Use //= instead of ||= in Handler::FCGI to allow passing "0" child processes. This makes FCGI::ProcManager run within a single process. See http://search.cpan.org/~gbjk/FCGI-ProcManager-0.19/ProcManager.pm#pm_manage

Result:

Debugging is possible.

