### PR TITLE
Faster header utils

### DIFF
--- a/lib/Plack/Util.pm
+++ b/lib/Plack/Util.pm
@@ -204,12 +204,12 @@ sub header_push {
 sub header_exists {
     my($headers, $key) = (shift, lc shift);
 
-    my $exists;
-    header_iter $headers, sub {
-        $exists = 1 if lc $_[0] eq $key;
-    };
+    my $check;
+    for (@$headers) {
+        return 1 if ($check = not $check) and $key eq lc;
+    }
 
-    return $exists;
+    return !1;
 }
 
 sub header_remove {

--- a/lib/Plack/Util.pm
+++ b/lib/Plack/Util.pm
@@ -215,13 +215,15 @@ sub header_exists {
 sub header_remove {
     my($headers, $key) = (shift, lc shift);
 
-    my @new_headers;
-    header_iter $headers, sub {
-        push @new_headers, $_[0], $_[1]
-            unless lc $_[0] eq $key;
-    };
+    return if not @$headers;
 
-    @$headers = @new_headers;
+    my $keep;
+    my @keep = grep {
+        $_ & 1 ? $keep : ($keep = $key ne lc $headers->[$_]);
+    } 0 .. $#$headers;
+
+    @$headers = @$headers[@keep] if @keep < @$headers;
+    ();
 }
 
 sub status_with_no_entity_body {

--- a/lib/Plack/Util.pm
+++ b/lib/Plack/Util.pm
@@ -174,12 +174,22 @@ sub header_iter {
 sub header_get {
     my($headers, $key) = (shift, lc shift);
 
-    my @val;
-    header_iter $headers, sub {
-        push @val, $_[1] if lc $_[0] eq $key;
-    };
+    return () if not @$headers;
 
-    return wantarray ? @val : $val[0];
+    my $i = 0;
+
+    if (wantarray) {
+        return map {
+            $key eq lc $headers->[$i++] ? $headers->[$i++] : ++$i && ();
+        } 1 .. @$headers/2;
+    }
+
+    while ($i < @$headers) {
+        return $headers->[$i+1] if $key eq lc $headers->[$i];
+        $i += 2;
+    }
+
+    ();
 }
 
 sub header_set {


### PR DESCRIPTION
`header_exists` and scalar-context `header_get` can short-circuit, and `header_set` and `header_remove` can do their work in one-shot, list-wise operations instead of looping and pushing and copying. And of course it’s always faster to do the work in native loops instead of lots of short function calls plus copying data to globals.

The readability of the code did not even suffer that much, to my mind; `header_set` seems maybe slightly more readable even, and `header_exist` is just as readable as before. The other two have suffered, but not terribly.