### PR TITLE
Fix parsing of empty query string pairs

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -88,7 +88,7 @@ sub _parse_query {
     if (defined $query_string) {
         @query =
             map { s/\+/ /g; URI::Escape::uri_unescape($_) }
-            map { /=/ ? split(/=/, $_, 2) : ($_ => '')}
+            map { '' eq $_ ? () : /=/ ? split(/=/, $_, 2) : ($_ => '') }
             split(/[&;]/, $query_string);
     }
 

--- a/t/Plack-Request/params.t
+++ b/t/Plack-Request/params.t
@@ -21,6 +21,8 @@ is $req->param('foo'), "baz";
 is_deeply [ $req->param('foo') ] , [ qw(bar baz) ];
 is_deeply [ sort $req->param ], [ 'bar', 'foo' ];
 
+my $req = Plack::Request->new({ QUERY_STRING => "&&foo=bar" });
+is_deeply $req->parameters, { foo => "bar" };
 
 done_testing;
 


### PR DESCRIPTION
Plack::Request has a bug (apparently shared with URI::_query) in how it parses empty pairs in the query string. It produces an empty-string key with an empty-key value, rather than ignoring them.

This patch fixes the problem.