### PR TITLE
Fix parsing of empty query string pairs better

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -86,10 +86,11 @@ sub _parse_query {
     my @query;
     my $query_string = $self->env->{QUERY_STRING};
     if (defined $query_string) {
+        $query_string =~ s/\A[&;]+//;
         @query =
             map { s/\+/ /g; URI::Escape::uri_unescape($_) }
-            map { '' eq $_ ? () : /=/ ? split(/=/, $_, 2) : ($_ => '') }
-            split(/[&;]/, $query_string);
+            map { /=/ ? split(/=/, $_, 2) : ($_ => '')}
+            split(/[&;]+/, $query_string);
     }
 
     Hash::MultiValue->new(@query);

--- a/t/Plack-Request/params.t
+++ b/t/Plack-Request/params.t
@@ -21,8 +21,8 @@ is $req->param('foo'), "baz";
 is_deeply [ $req->param('foo') ] , [ qw(bar baz) ];
 is_deeply [ sort $req->param ], [ 'bar', 'foo' ];
 
-my $req = Plack::Request->new({ QUERY_STRING => "&&foo=bar" });
-is_deeply $req->parameters, { foo => "bar" };
+my $req = Plack::Request->new({ QUERY_STRING => "&&foo=bar&&baz=quux" });
+is_deeply $req->parameters, { foo => 'bar', baz => 'quux' };
 
 done_testing;
 


### PR DESCRIPTION
This changes the test to include empty pairs both at the start and in the middle of the string.

Also it avoids the check for empty pairs in every iteration of the `map` by splitting not just on single separators, but on sequences of any number of separators – then the split doesn’t produce empty pairs in the first place. The remaining exception is that it can still do so at the start of the string, so the code first throws away any sequence of leading separators.