### PR TITLE
Add .webm to Plack::MIME as 'video/webm'

### DIFF
--- a/lib/Plack/MIME.pm
+++ b/lib/Plack/MIME.pm
@@ -155,6 +155,7 @@ our $MIME_TYPES = {
     ".vrml"    => "model/vrml",
     ".war"     => "application/java-archive",
     ".wav"     => "audio/x-wav",
+    ".webm"    => "video/webm",
     ".wma"     => "audio/x-ms-wma",
     ".wmv"     => "video/x-ms-wmv",
     ".wmx"     => "video/x-ms-wmx",


### PR DESCRIPTION
Probably best to include .webm by default since its a standard and is being used more and more when serving video.