### PR TITLE
add expires attribute to cookie if expires value is defined

### DIFF
--- a/lib/Plack/Response.pm
+++ b/lib/Plack/Response.pm
@@ -138,7 +138,7 @@ sub _bake_cookie {
     my @cookie = ( URI::Escape::uri_escape($name) . "=" . URI::Escape::uri_escape($val->{value}) );
     push @cookie, "domain=" . $val->{domain}   if $val->{domain};
     push @cookie, "path=" . $val->{path}       if $val->{path};
-    push @cookie, "expires=" . $self->_date($val->{expires}) if $val->{expires};
+    push @cookie, "expires=" . $self->_date($val->{expires}) if defined $val->{expires};
     push @cookie, "max-age=" . $val->{"max-age"} if $val->{"max-age"};
     push @cookie, "secure"                     if $val->{secure};
     push @cookie, "HttpOnly"                   if $val->{httponly};

--- a/t/Plack-Response/cookie.t
+++ b/t/Plack-Response/cookie.t
@@ -10,6 +10,7 @@ my $app = sub {
     $res->cookies->{t1} = { value => "bar", domain => '.example.com', path => '/cgi-bin' };
     $res->cookies->{t2} = { value => "xxx yyy", expires => time + 3600 };
     $res->cookies->{t3} = { value => "123123", "max-age" => 15 };
+    $res->cookies->{t4} = { value => "foo", expires => 0 };
     $res->finalize;
 };
 
@@ -21,6 +22,7 @@ test_psgi $app, sub {
     is $v[0], "t1=bar; domain=.example.com; path=/cgi-bin";
     like $v[1], qr/t2=xxx%20yyy; expires=\w+, \d+-\w+-\d+ \d\d:\d\d:\d\d GMT/;
     is $v[2], "t3=123123; max-age=15";
+    is $v[3], "t4=foo; expires=Thu, 01-Jan-1970 00:00:00 GMT";
 };
 
 done_testing;


### PR DESCRIPTION
Noticed that an expires value of 0 was being ignored.

Changed to check for definedness. Test added.