### PR TITLE
[lint] do not forbid SERVER_PROTOCOL=HTTP/2

### DIFF
--- a/lib/Plack/Middleware/Lint.pm
+++ b/lib/Plack/Middleware/Lint.pm
@@ -57,7 +57,7 @@ sub validate_env {
     if ($env->{SERVER_PORT} eq '') {
         die('SERVER_PORT must not be empty string');
     }
-    if (defined($env->{SERVER_PROTOCOL}) and $env->{SERVER_PROTOCOL} !~ m{^HTTP/1.\d$}) {
+    if (defined($env->{SERVER_PROTOCOL}) and $env->{SERVER_PROTOCOL} !~ m{^HTTP/\d}) {
         die("Invalid SERVER_PROTOCOL: $env->{SERVER_PROTOCOL}");
     }
     for my $param (qw/version url_scheme input errors multithread multiprocess/) {

--- a/t/Plack-Middleware/lint_env.t
+++ b/t/Plack-Middleware/lint_env.t
@@ -20,7 +20,7 @@ my @bad_env = (
     [ { REQUEST_METHOD => "foo" },, qr/Invalid env param: REQUEST_METHOD/ ],
     [ { PATH_INFO => 'foo' }, qr/PATH_INFO must begin with \// ],
     [ { SERVER_PORT => undef }, qr/Missing mandatory .*SERVER_PORT/ ],
-    [ { SERVER_PROTOCOL => 'HTTP/2.2' }, qr/Invalid SERVER_PROTOCOL/ ],
+    [ { SERVER_PROTOCOL => 'HTTP/x' }, qr/Invalid SERVER_PROTOCOL/ ],
     [ { "psgi.version" => 2 }, qr/psgi\.version should be ArrayRef/ ],
     [ { HTTP_CONTENT_TYPE => "text/plain" }, qr/HTTP_CONTENT_TYPE should not exist/ ],
 );


### PR DESCRIPTION
Plack::Middleware::Lint is handler-agnostic lint; it should accept `SERVER_PROTOCOL`=`HTTP/2` as well.

My case was that when using `Plack::Handler::FCGI` behind [H2O](https://github.com/h2o/h2o), Lint was complaining about `SERVER_PROTOCOL` being set to `HTTP/2`.