### PR TITLE
Added MIME type for Android APK

### DIFF
--- a/lib/Plack/MIME.pm
+++ b/lib/Plack/MIME.pm
@@ -8,6 +8,7 @@ our $MIME_TYPES = {
     ".ai"      => "application/postscript",
     ".aif"     => "audio/x-aiff",
     ".aiff"    => "audio/x-aiff",
+    ".apk"     => "application/vnd.android.package-archive",
     ".asc"     => "application/pgp-signature",
     ".asf"     => "video/x-ms-asf",
     ".asm"     => "text/x-asm",


### PR DESCRIPTION
Added a MIME type for the Android APK format.

Chrome and the old Android Browser handle APKs fine without a MIME type but Firefox for Android requires that the MIME Type is correct in order to prompt the user to install an app (otherwise it just shows binary data in the browser).

This addition allows (among other things) APKs to be served to Firefox on Android by Plack::Middleware::Static without having to manually add a type.