### PR TITLE
Shouldn't "return outside a subroutine"

### DIFF
--- a/lib/Plack/Runner.pm
+++ b/lib/Plack/Runner.pm
@@ -325,7 +325,8 @@ script, you can do this:
       require Plack::Runner;
       my $runner = Plack::Runner->new;
       $runner->parse_options(@ARGV);
-      return $runner->run($app);
+      $runner->run($app);
+      exit 0;
   }
 
   return $app;


### PR DESCRIPTION
In the "directly called" case (i.e. caller is false) we're not running in a sub or a frame from where we can return, so it's a bit weird to put return there.