### PR TITLE
Support setting "manager" for Plack::Handler::FCGI in single-process mode

### DIFF
--- a/lib/Plack/Handler/FCGI.pm
+++ b/lib/Plack/Handler/FCGI.pm
@@ -91,13 +91,15 @@ sub run {
 
             # detach *before* the ProcManager inits
             $self->daemon_detach if $self->{daemonize};
-
-            $proc_manager->pm_manage;
         }
         elsif ($self->{daemonize}) {
             $self->daemon_detach;
         }
+    } elsif (blessed $self->{manager}) {
+        $proc_manager = $self->{manager};
     }
+
+    $proc_manager && $proc_manager->pm_manage;
 
     while ($request->Accept >= 0) {
         $proc_manager && $proc_manager->pm_pre_dispatch;


### PR DESCRIPTION
FCGI::ProcManager supports running in single-process mode when
n_processes is zero. It is useful (for harakiri support) to run
with proc manager in single-process mode.

This refactors _create_proc_manager method to create the manager
object. It uses different default manager class and number processes between
listen mode and single process mode. It keeps the old behavior for
single-process mode without manager. It would be possible to create proc manager by default or always.
