### PR TITLE
replace HTTP::Body with HTTP::Entity::Parser and optimize query_parameters

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -16,8 +16,8 @@ requires 'URI', '1.59';
 requires 'parent';
 requires 'Apache::LogFormat::Compiler', '0.12';
 requires 'HTTP::Tiny', 0.034;
-requires 'HTTP::Entity::Parser', 0.16;
-requires 'WWW::Form::UrlEncoded', 0.22;
+requires 'HTTP::Entity::Parser', 0.17;
+requires 'WWW::Form::UrlEncoded', 0.23;
 
 on test => sub {
     requires 'Test::More', '0.88';

--- a/cpanfile
+++ b/cpanfile
@@ -5,7 +5,6 @@ requires 'Devel::StackTrace', '1.23';
 requires 'Devel::StackTrace::AsHTML', '0.11';
 requires 'File::ShareDir', '1.00';
 requires 'Filesys::Notify::Simple';
-requires 'HTTP::Body', '1.06';
 requires 'HTTP::Message', '5.814';
 requires 'HTTP::Headers::Fast', '0.18';
 requires 'Hash::MultiValue', '0.05';
@@ -17,6 +16,8 @@ requires 'URI', '1.59';
 requires 'parent';
 requires 'Apache::LogFormat::Compiler', '0.12';
 requires 'HTTP::Tiny', 0.034;
+requires 'HTTP::Entity::Parser', 0.03;
+requires 'WWW::Form::UrlEncoded', 0.22;
 
 on test => sub {
     requires 'Test::More', '0.88';

--- a/cpanfile
+++ b/cpanfile
@@ -16,7 +16,7 @@ requires 'URI', '1.59';
 requires 'parent';
 requires 'Apache::LogFormat::Compiler', '0.12';
 requires 'HTTP::Tiny', 0.034;
-requires 'HTTP::Entity::Parser', 0.15;
+requires 'HTTP::Entity::Parser', 0.16;
 requires 'WWW::Form::UrlEncoded', 0.22;
 
 on test => sub {

--- a/cpanfile
+++ b/cpanfile
@@ -16,7 +16,7 @@ requires 'URI', '1.59';
 requires 'parent';
 requires 'Apache::LogFormat::Compiler', '0.12';
 requires 'HTTP::Tiny', 0.034;
-requires 'HTTP::Entity::Parser', 0.03;
+requires 'HTTP::Entity::Parser', 0.15;
 requires 'WWW::Form::UrlEncoded', 0.22;
 
 on test => sub {

--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -232,13 +232,15 @@ sub new_response {
     Plack::Response->new(@_);
 }
 
-my $default_parser = HTTP::Entity::Parser->new();
-$default_parser->register('application/x-www-form-urlencoded', 'HTTP::Entity::Parser::UrlEncoded');
-$default_parser->register('multipart/form-data', 'HTTP::Entity::Parser::MultiPart');
-
 sub request_body_parser {
     my $self = shift;
-    $self->{request_body_parser} ||= $default_parser;
+    if ( !$self->{request_body_parser} ) {
+        my $default_parser = HTTP::Entity::Parser->new(exists $ENV{PLACK_BUFFER_LENGTH} ? (buffer_length => $ENV{PLACK_BUFFER_LENGTH}) : ());
+        $default_parser->register('application/x-www-form-urlencoded', 'HTTP::Entity::Parser::UrlEncoded');
+        $default_parser->register('multipart/form-data', 'HTTP::Entity::Parser::MultiPart');
+        $self->{request_body_parser} = $default_parser;
+    }
+    $self->{request_body_parser};
 }
 
 sub _parse_request_body {

--- a/t/Plack-Request/params.t
+++ b/t/Plack-Request/params.t
@@ -22,7 +22,7 @@ is_deeply [ $req->param('foo') ] , [ qw(bar baz) ];
 is_deeply [ sort $req->param ], [ 'bar', 'foo' ];
 
 $req = Plack::Request->new({ QUERY_STRING => "&&foo=bar&&baz=quux" });
-is_deeply $req->parameters, { foo => 'bar', baz => 'quux' };
+is_deeply $req->parameters, { "" => "", foo => 'bar', baz => 'quux' };
 
 done_testing;
 


### PR DESCRIPTION
related to #537 and #434

This PR replace HTTP::Body with HTTP::Entity::Parser and WWW::Form::UrlEncoded(::XS). HTTP::Entity::Parser was created based on tokuhirom's code of #434.

And also this PR remove `Hash::MultiValue->flatten` in `parameters` for reducing cost.

Here is small benchmark this pr and master.

use HTTP::Entity::Parser and WWW::Form::UrlEncoded::XS

```
% perl -Ilib entity_parser_bench.pl
Benchmark: running get, noparam, post for at least 3 CPU seconds...
       get:  3 wallclock secs ( 3.11 usr +  0.00 sys =  3.11 CPU) @ 6381.03/s (n=19845)
   noparam:  3 wallclock secs ( 3.09 usr +  0.00 sys =  3.09 CPU) @ 7336.57/s (n=22670)
      post:  3 wallclock secs ( 3.30 usr +  0.00 sys =  3.30 CPU) @ 5225.15/s (n=17243)
          Rate    post     get noparam
post    5225/s      --    -18%    -29%
get     6381/s     22%      --    -13%
noparam 7337/s     40%     15%      --
```

master(0fbe07327b6caacdeb798ce06c3236f3af3178a2)

```
% perl -Ilib entity_parser_bench.pl
Benchmark: running get, noparam, post for at least 3 CPU seconds...
       get:  3 wallclock secs ( 3.03 usr +  0.00 sys =  3.03 CPU) @ 4884.49/s (n=14800)
   noparam:  3 wallclock secs ( 3.34 usr +  0.00 sys =  3.34 CPU) @ 6130.24/s (n=20475)
      post:  3 wallclock secs ( 3.05 usr +  0.00 sys =  3.05 CPU) @ 3472.79/s (n=10592)
          Rate    post     get noparam
post    3473/s      --    -29%    -43%
get     4884/s     41%      --    -20%
noparam 6130/s     77%     26%      --
```

