### PR TITLE
Added `header_parameters` to `Plack::Request`.

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -134,11 +134,11 @@ sub headers {
 
 sub header_parameters {
     my $self = shift;
-
-    return Hash::MultiValue->from_mixed(
-        map { $_ => +[ split /,\ */ => ($self->headers->header($_))[0] ] }
-        $self->headers->header_field_names
-    );
+    my %mixed;
+    for my $k ( $self->headers->header_field_names ) {
+        $mixed{$k} = +[ map {split /,\ */} $self->headers->header($k) ];
+    }
+    return Hash::MultiValue->from_mixed(%mixed);
 }
 
 sub content_encoding { shift->headers->content_encoding(@_) }

--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -132,6 +132,15 @@ sub headers {
     $self->{headers};
 }
 
+sub header_parameters {
+    my $self = shift;
+
+    return Hash::MultiValue->from_mixed(
+        map { $_ => +[ split ', ' => $self->headers->header($_) ] }
+        $self->headers->header_field_names
+    );
+}
+
 sub content_encoding { shift->headers->content_encoding(@_) }
 sub header           { shift->headers->header(@_) }
 sub referer          { shift->headers->referer(@_) }
@@ -472,6 +481,12 @@ Returns a reference to a hash containing posted parameters in the
 request body (POST). As with C<query_parameters>, the hash
 reference is a L<Hash::MultiValue> object.
 
+=item header_parameters
+
+Returns a reference to a hash containing posted parameters in the
+request HEADERS. As with C<query_parameters>, the hash
+reference is a L<Hash::MultiValue> object.
+
 =item parameters
 
 Returns a L<Hash::MultiValue> hash reference containing (merged) GET
@@ -579,11 +594,11 @@ generation in middlewares.
 =head2 Hash::MultiValue parameters
 
 Parameters that can take one or multiple values (i.e. C<parameters>,
-C<query_parameters>, C<body_parameters> and C<uploads>) store the
-hash reference as a L<Hash::MultiValue> object. This means you can use
-the hash reference as a plain hash where values are B<always> scalars
-(B<NOT> array references), so you don't need to code ugly and unsafe
-C<< ref ... eq 'ARRAY' >> anymore.
+C<query_parameters>, C<body_parameters>, C<header_parameters> and
+C<uploads>) store the hash reference as a L<Hash::MultiValue> object.
+This means you can use the hash reference as a plain hash where values
+are B<always> scalars (B<NOT> array references), so you don't need to
+code ugly and unsafe C<< ref ... eq 'ARRAY' >> anymore.
 
 And if you explicitly want to get multiple values of the same key, you
 can call the C<get_all> method on it, such as:
@@ -651,10 +666,10 @@ most methods are made read-only. These methods were deleted in version
 1.0001.
 
 All parameter-related methods such as C<parameters>,
-C<body_parameters>, C<query_parameters> and C<uploads> now contains
-L<Hash::MultiValue> objects, rather than I<scalar or an array
-reference depending on the user input> which is insecure. See
-L<Hash::MultiValue> for more about this change.
+C<body_parameters>, C<query_parameters>, C<header_parameters> and
+C<uploads> now contains L<Hash::MultiValue> objects, rather than
+I<scalar or an array reference depending on the user input> which is
+insecure. See L<Hash::MultiValue> for more about this change.
 
 C<< $req->path >> method had a bug, where the code and the document
 was mismatching. The document was suggesting it returns the sub

--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -136,7 +136,7 @@ sub header_parameters {
     my $self = shift;
 
     return Hash::MultiValue->from_mixed(
-        map { $_ => +[ split ', ' => $self->headers->header($_) ] }
+        map { $_ => +[ split /,\ */ => $self->headers->header($_) ] }
         $self->headers->header_field_names
     );
 }

--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -136,7 +136,7 @@ sub header_parameters {
     my $self = shift;
 
     return Hash::MultiValue->from_mixed(
-        map { $_ => +[ split /,\ */ => $self->headers->header($_) ] }
+        map { $_ => +[ split /,\ */ => ($self->headers->header($_))[0] ] }
         $self->headers->header_field_names
     );
 }

--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -134,10 +134,12 @@ sub headers {
 
 sub header_parameters {
     my $self = shift;
-    return Hash::MultiValue->from_mixed(
-        map { $_ => +[ split /,\ */ => scalar $self->headers->header($_) ] }
-        $self->headers->header_field_names
-    );
+
+    $self->env->{'plack.request.headers'} ||=
+        Hash::MultiValue->from_mixed(
+            map { $_ => +[ split /,\ */ => scalar $self->headers->header($_) ] }
+            $self->headers->header_field_names
+        );
 }
 
 sub content_encoding { shift->headers->content_encoding(@_) }

--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -134,11 +134,10 @@ sub headers {
 
 sub header_parameters {
     my $self = shift;
-    my %mixed;
-    for my $k ( $self->headers->header_field_names ) {
-        $mixed{$k} = +[ map {split /,\ */} $self->headers->header($k) ];
-    }
-    return Hash::MultiValue->from_mixed(%mixed);
+    return Hash::MultiValue->from_mixed(
+        map { $_ => +[ split /,\ */ => scalar $self->headers->header($_) ] }
+        $self->headers->header_field_names
+    );
 }
 
 sub content_encoding { shift->headers->content_encoding(@_) }

--- a/t/Plack-Request/headers.t
+++ b/t/Plack-Request/headers.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+use Plack::Test;
+use Plack::Request;
+use HTTP::Request::Common;
+
+my $app = sub {
+    my $req = Plack::Request->new(shift);
+    my $headers = $req->header_parameters;
+    is $headers->get('X-PLACK-REQUEST-HEADER-TEST'), 'foo';
+    is $req->header('X-PLACK-REQUEST-HEADER-TEST'), 'foo';
+    $req->new_response(200)->finalize;
+};
+
+test_psgi $app, sub {
+    my $cb = shift;
+    my $res = $cb->(GET "/", 'X-PLACK-REQUEST-HEADER-TEST' => 'foo');
+    ok $res->is_success;
+};
+
+done_testing;

--- a/t/Plack-Request/headers.t
+++ b/t/Plack-Request/headers.t
@@ -5,18 +5,60 @@ use Plack::Test;
 use Plack::Request;
 use HTTP::Request::Common;
 
-my $app = sub {
-    my $req = Plack::Request->new(shift);
-    my $headers = $req->header_parameters;
-    is $headers->get('X-PLACK-REQUEST-HEADER-TEST'), 'foo';
-    is $req->header('X-PLACK-REQUEST-HEADER-TEST'), 'foo';
-    $req->new_response(200)->finalize;
+subtest 'basic' => sub {
+    my $app = sub {
+        my $req = Plack::Request->new(shift);
+        my $headers = $req->header_parameters;
+        is $headers->get('X-PLACK-REQUEST-HEADER-TEST'), 'foo';
+        is $req->header('X-PLACK-REQUEST-HEADER-TEST'), 'foo';
+        $req->new_response(200)->finalize;
+    };
+
+    test_psgi $app, sub {
+        my $cb = shift;
+        my $res = $cb->(GET "/", 'X-PLACK-REQUEST-HEADER-TEST' => 'foo');
+        ok $res->is_success;
+    };
 };
 
-test_psgi $app, sub {
-    my $cb = shift;
-    my $res = $cb->(GET "/", 'X-PLACK-REQUEST-HEADER-TEST' => 'foo');
-    ok $res->is_success;
+subtest 'multi-values' => sub {
+    my $app = sub {
+        my $req = Plack::Request->new(shift);
+        my $headers = $req->header_parameters;
+        is_deeply(
+            [ $headers->get_all('X-PLACK-REQUEST-HEADER-TEST') ],
+            [qw< foo bar baz >]
+        );
+        $req->new_response(200)->finalize;
+    };
+
+    test_psgi $app, sub {
+        my $cb = shift;
+        my $res = $cb->(GET "/", 'X-PLACK-REQUEST-HEADER-TEST' => 'foo, bar, baz');
+        ok $res->is_success;
+    };
+};
+
+subtest 'multi-lines' => sub {
+    my $app = sub {
+        my $req = Plack::Request->new(shift);
+        my $headers = $req->header_parameters;
+        is_deeply(
+            [ $headers->get_all('X-PLACK-REQUEST-HEADER-TEST') ],
+            [qw< foo bar baz >]
+        );
+        $req->new_response(200)->finalize;
+    };
+
+    test_psgi $app, sub {
+        my $cb = shift;
+        my $res = $cb->(
+            GET "/",
+            'X-PLACK-REQUEST-HEADER-TEST' => 'foo, bar',
+            'X-PLACK-REQUEST-HEADER-TEST' => 'baz'
+        );
+        ok $res->is_success;
+    };
 };
 
 done_testing;

--- a/t/Plack-Request/parameters.t
+++ b/t/Plack-Request/parameters.t
@@ -8,9 +8,9 @@ use HTTP::Request::Common;
 my $app = sub {
     my $req = Plack::Request->new(shift);
     my $b = $req->body_parameters;
-    is $b->get('foo'), 'bar';
+    is $b->{foo}, 'bar';
     my $q = $req->query_parameters;
-    is $q->get('bar'), 'baz';
+    is $q->{bar}, 'baz';
     my $h = $req->header_parameters;
     is $h->get('QUX'), 'quux';
 

--- a/t/Plack-Request/parameters.t
+++ b/t/Plack-Request/parameters.t
@@ -8,9 +8,11 @@ use HTTP::Request::Common;
 my $app = sub {
     my $req = Plack::Request->new(shift);
     my $b = $req->body_parameters;
-    is $b->{foo}, 'bar';
+    is $b->get('foo'), 'bar';
     my $q = $req->query_parameters;
-    is $q->{bar}, 'baz';
+    is $q->get('bar'), 'baz';
+    my $h = $req->header_parameters;
+    is $h->get('QUX'), 'quux';
 
     is_deeply $req->parameters, { foo => 'bar', 'bar' => 'baz' };
 
@@ -19,7 +21,7 @@ my $app = sub {
 
 test_psgi $app, sub {
     my $cb = shift;
-    $cb->(POST "/?bar=baz", { foo => "bar" });
+    $cb->(POST "/?bar=baz", QUX => 'quux', Content => [ foo => "bar" ]);
 };
 
 done_testing;


### PR DESCRIPTION
I wish to be able to read headers as HMV without having to parse them separately on every app.
I think they should be treated the same as query/body parameters.

cheer,
Mickey

This method allows reading the request headers as a
`Hash::MultiValue` object like `query_parameters` or
`body_parameters`.

Also added the appropriate tests & documentation.