### PR TITLE
use HTTP::Headers::Fast->flatten introduced 0.20

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -7,7 +7,7 @@ requires 'File::ShareDir', '1.00';
 requires 'Filesys::Notify::Simple';
 requires 'HTTP::Body', '1.06';
 requires 'HTTP::Message', '5.814';
-requires 'HTTP::Headers::Fast', '0.18';
+requires 'HTTP::Headers::Fast', '0.20';
 requires 'Hash::MultiValue', '0.05';
 requires 'Pod::Usage', '1.36';
 requires 'Stream::Buffered', '0.02';

--- a/lib/Plack/Response.pm
+++ b/lib/Plack/Response.pm
@@ -86,20 +86,12 @@ sub finalize {
     my $self = shift;
     Carp::croak "missing status" unless $self->status();
 
-    my $headers = $self->headers;
-    my @headers;
-    $headers->scan(sub{
-        my ($k,$v) = @_;
-        $v =~ s/\015\012[\040|\011]+/chr(32)/ge; # replace LWS with a single SP
-        $v =~ s/\015|\012//g; # remove CR and LF since the char is invalid here
-        push @headers, $k, $v;
-    });
-
-    $self->_finalize_cookies(\@headers);
+    my $headers = $self->headers->flatten;
+    $self->_finalize_cookies($headers);
 
     return [
         $self->status,
-        \@headers,
+        $headers,
         $self->_body,
     ];
 }


### PR DESCRIPTION
`HTTP::Headers::Fast->flatten` was introduced in https://github.com/tokuhirom/HTTP-Headers-Fast/pull/8. `flatten` is shortcut method for building PSGI compatible header array. This PR uses that.

benchmark. Would be 10% faster.

master

```
% perl bench.pl
Benchmark: running bench_hello for at least 3 CPU seconds...
bench_hello:  4 wallclock secs ( 3.22 usr +  0.00 sys =  3.22 CPU) @ 60104.35/s (n=193536)
               Rate bench_hello
bench_hello 60104/s          --
```

This PR

```
% perl -Ilib bench.pl
Benchmark: running bench_hello for at least 3 CPU seconds...
bench_hello:  4 wallclock secs ( 3.30 usr +  0.01 sys =  3.31 CPU) @ 66011.48/s (n=218498)
               Rate bench_hello
bench_hello 66011/s          --
```

benchmark script

```
use HTTP::Request::Common;
use HTTP::Message::PSGI;
use Plack::Response;
use Benchmark qw/cmpthese timethese/;

my $env = req_to_psgi(GET "/");
my $app = sub {
    my $res = Plack::Response->new(200);
    $res->content_type('text/plain');
    $res->body("Hello World\n");
    $res->finalize;
};

cmpthese(timethese(0,{
    'bench_hello' => sub {
        $app->($env);
    }
}));


```