### PR TITLE
Allow log4perl.t and log4perl-category.t to run in parallel

### DIFF
--- a/t/Plack-Middleware/log4perl-category.t
+++ b/t/Plack-Middleware/log4perl-category.t
@@ -6,7 +6,7 @@ use Test::More;
 use Plack::Middleware::Log4perl;
 use HTTP::Request::Common;
 
-my $test_file = "t/Plack-Middleware/log4perl.log";
+my $test_file = "t/Plack-Middleware/log4perl-category.log";
 
 my $conf = <<CONF;
 log4perl.logger.0 = INFO, Logfile


### PR DESCRIPTION
This fixes #543, in which `t/Plack-Middleware/log4perl.t` and `t/Plack-Middleware/log4perl-category.t` may attempt to access the same log file while running in parallel via the `-j` flag.