### PR TITLE
white space issue causes failing test if run

### DIFF
--- a/lib/Plack/Test.pm
+++ b/lib/Plack/Test.pm
@@ -52,7 +52,7 @@ Plack::Test - Test PSGI applications with various backends
   use HTTP::Request::Common;
 
   # Simple OO interface
-  my $app = sub { return [ 200, [], [ "Hello" ] ] };S
+  my $app = sub { return [ 200, [], [ "Hello" ] ] };
   my $test = Plack::Test->create($app);
 
   my $res = $test->request(GET "/");

--- a/lib/Plack/Test.pm
+++ b/lib/Plack/Test.pm
@@ -52,7 +52,7 @@ Plack::Test - Test PSGI applications with various backends
   use HTTP::Request::Common;
 
   # Simple OO interface
-  my $app = sub { return [ 200, [], [ "Hello "] ] };
+  my $app = sub { return [ 200, [], [ "Hello" ] ] };S
   my $test = Plack::Test->create($app);
 
   my $res = $test->request(GET "/");
@@ -72,7 +72,7 @@ Plack::Test - Test PSGI applications with various backends
       };
 
   # positional params (app, client)
-  my $app = sub { return [ 200, [], [ "Hello "] ] };
+  my $app = sub { return [ 200, [], [ "Hello" ] ] };
   test_psgi $app, sub {
       my $cb  = shift;
       my $res = $cb->(GET "/");


### PR DESCRIPTION
I noticed a spacing issue with the docs on Plack::Test, figured it was a simple fix to just tidy them up so that if some one was to copy/paste this code it would pass as intended. 