### PR TITLE
 Avoid race conditions in tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Go to http://github.com/plack/Plack/issues for the roadmap and known issues.
 
 {{$NEXT}}
+    [IMPROVEMENTS]
+        - Allow passing an already-open listen socket to HTTP::Server::PSGI
+          and do so in Plack::Test::Server.
 
 1.0039  2015-12-06 03:27:59 PST
     [BUG FIXES]

--- a/cpanfile
+++ b/cpanfile
@@ -10,7 +10,7 @@ requires 'HTTP::Headers::Fast', '0.18';
 requires 'Hash::MultiValue', '0.05';
 requires 'Pod::Usage', '1.36';
 requires 'Stream::Buffered', '0.02';
-requires 'Test::TCP', '2.00';
+requires 'Test::TCP', '2.15';
 requires 'Try::Tiny';
 requires 'URI', '1.59';
 requires 'parent';

--- a/lib/HTTP/Server/PSGI.pm
+++ b/lib/HTTP/Server/PSGI.pm
@@ -35,8 +35,14 @@ sub new {
     my($class, %args) = @_;
 
     my $self = bless {
-        host               => $args{host} || 0,
-        port               => $args{port} || 8080,
+        ($args{listen_sock} ? (
+            listen_sock    => $args{listen_sock},
+            host           => $args{listen_sock}->sockhost,
+            port           => $args{listen_sock}->sockport,
+        ):(
+            host           => $args{host} || 0,
+            port           => $args{port} || 8080,
+        )),
         timeout            => $args{timeout} || 300,
         server_software    => $args{server_software} || $class,
         server_ready       => $args{server_ready} || sub {},
@@ -82,17 +88,19 @@ sub prepare_socket_class {
 sub setup_listener {
     my $self = shift;
 
-    my %args = (
-        Listen    => SOMAXCONN,
-        LocalPort => $self->{port},
-        LocalAddr => $self->{host},
-        Proto     => 'tcp',
-        ReuseAddr => 1,
-    );
+    $self->{listen_sock} ||= do {
+        my %args = (
+            Listen    => SOMAXCONN,
+            LocalPort => $self->{port},
+            LocalAddr => $self->{host},
+            Proto     => 'tcp',
+            ReuseAddr => 1,
+        );
 
-    my $class = $self->prepare_socket_class(\%args);
-    $self->{listen_sock} ||= $class->new(%args)
-        or die "failed to listen to port $self->{port}: $!";
+        my $class = $self->prepare_socket_class(\%args);
+        $class->new(%args)
+            or die "failed to listen to port $self->{port}: $!";
+    };
 
     $self->{server_ready}->({ %$self, proto => $self->{ssl} ? 'https' : 'http' });
 }

--- a/lib/Plack/Test/Server.pm
+++ b/lib/Plack/Test/Server.pm
@@ -12,9 +12,11 @@ sub new {
     my($class, $app, %args) = @_;
 
     my $server = Test::TCP->new(
+        listen => 1,
+        host => $args{host},
         code => sub {
-            my $port = shift;
-            my $server = Plack::Loader->auto(port => $port, host => ($args{host} || '127.0.0.1'));
+            my $socket = shift;
+            my $server = Plack::Loader->auto(listen_sock => $socket);
             $server->run($app);
             exit;
         },

--- a/t/HTTP-Server-PSGI/harakiri.t
+++ b/t/HTTP-Server-PSGI/harakiri.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Plack::Runner;
+use Plack::Loader;
 use Test::More;
 use Test::TCP;
 use Test::Requires qw(LWP::UserAgent);
@@ -9,11 +9,11 @@ use Test::Requires qw(LWP::UserAgent);
 my $ua_timeout = 3;
 
 test_tcp(
+    listen => 1,
     server => sub {
-        my $port = shift;
-        my $runner = Plack::Runner->new;
-        $runner->parse_options("--host" => "127.0.0.1", "--port" => $port, "-E", "dev", "-s", "HTTP::Server::PSGI");
-        $runner->run(
+        my $socket = shift;
+        my $server = Plack::Loader->auto(listen_sock => $socket);
+        $server->run(
             sub {
                 my $env = shift;
                 if ($env->{PATH_INFO} eq '/kill') {

--- a/t/HTTP-Server-PSGI/listen.t
+++ b/t/HTTP-Server-PSGI/listen.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+
+use HTTP::Server::PSGI;
+use Test::More;
+use Test::TCP;
+use Test::Requires qw(LWP::UserAgent);
+
+my $ua_timeout = 3;
+
+test_tcp(
+    listen => 1,
+    server => sub {
+        my $socket = shift;
+        my $server = HTTP::Server::PSGI->new(
+            listen_sock => $socket,
+        );
+        $server->run(
+            sub {
+                my $env = shift;
+                return [
+                    200,
+                    [ 'Content-Type' => 'text/plain' ],
+                    [ "Hi" ],
+                ];
+            },
+        );
+    },
+    client => sub {
+        my $port = shift;
+        my $ua = LWP::UserAgent->new;
+        my $res = $ua->get("http://127.0.0.1:$port/");
+        ok $res->is_success;
+        is $res->code, 200;
+        is $res->content, 'Hi';
+    },
+);
+
+done_testing;

--- a/t/HTTP-Server-PSGI/post.t
+++ b/t/HTTP-Server-PSGI/post.t
@@ -1,17 +1,17 @@
 use strict;
 use warnings;
 
-use Plack::Runner;
+use Plack::Loader;
 use Test::More;
 use Test::TCP;
 use Test::Requires qw(LWP::UserAgent);
 
 test_tcp(
+    listen => 1,
     server => sub {
-        my $port = shift;
-        my $runner = Plack::Runner->new;
-        $runner->parse_options("--host" => "127.0.0.1", "--port" => $port, "-E", "dev", "-s", "HTTP::Server::PSGI");
-        $runner->run(
+        my $socket = shift;
+        my $server = Plack::Loader->auto(listen_sock => $socket);
+        $server->run(
             sub {
                 my $env = shift;
                 my $buf = '';

--- a/t/Plack-Loader/restarter.t
+++ b/t/Plack-Loader/restarter.t
@@ -50,11 +50,12 @@ test_tcp(
 
         is $cb->()->content, $return_bodies[2];
     },
+    listen => 1,
     server => sub {
-        my $port = shift;
+        my $socket = shift;
 
         my $loader = Plack::Loader::Restarter->new;
-        my $server = $loader->auto(port => $port, host => '127.0.0.1');
+        my $server = $loader->auto(listen_sock => $socket);
         $loader->preload_app($builder);
         $loader->watch('t');
         $loader->run($server);


### PR DESCRIPTION
Adds a `listen_sock` option to HTTP::Server::PSGI and uses this in combination with the new `listen` option to `Test::TCP::test_tcp` (see https://github.com/tokuhirom/Test-TCP/pull/48) to avoid race conditions in the tests.