### PR TITLE
Make Plack::Middleware::AccessLog::Timed to record %D and %T fields properly

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -22,7 +22,7 @@ requires 'WWW::Form::UrlEncoded', 0.23;
 on test => sub {
     requires 'Test::More', '0.88';
     requires 'Test::Requires';
-    requires 'Test::MockTime::HiRes', '0.04';
+    requires 'Test::MockTime::HiRes', '0.05';
     suggests 'Authen::Simple::Passwd';
     suggests 'MIME::Types';
     suggests 'CGI::Emulate::PSGI';

--- a/cpanfile
+++ b/cpanfile
@@ -22,6 +22,7 @@ requires 'WWW::Form::UrlEncoded', 0.23;
 on test => sub {
     requires 'Test::More', '0.88';
     requires 'Test::Requires';
+    requires 'Test::MockTime::HiRes', '0.04';
     suggests 'Authen::Simple::Passwd';
     suggests 'MIME::Types';
     suggests 'CGI::Emulate::PSGI';

--- a/cpanfile
+++ b/cpanfile
@@ -14,7 +14,7 @@ requires 'Test::TCP', '2.00';
 requires 'Try::Tiny';
 requires 'URI', '1.59';
 requires 'parent';
-requires 'Apache::LogFormat::Compiler', '0.12';
+requires 'Apache::LogFormat::Compiler', '0.33';
 requires 'HTTP::Tiny', 0.034;
 requires 'HTTP::Entity::Parser', 0.17;
 requires 'WWW::Form::UrlEncoded', 0.23;

--- a/cpanfile
+++ b/cpanfile
@@ -22,7 +22,7 @@ requires 'WWW::Form::UrlEncoded', 0.23;
 on test => sub {
     requires 'Test::More', '0.88';
     requires 'Test::Requires';
-    requires 'Test::MockTime::HiRes', '0.05';
+    requires 'Test::MockTime::HiRes', '0.06';
     suggests 'Authen::Simple::Passwd';
     suggests 'MIME::Types';
     suggests 'CGI::Emulate::PSGI';

--- a/lib/Plack/Middleware/AccessLog/Timed.pm
+++ b/lib/Plack/Middleware/AccessLog/Timed.pm
@@ -10,7 +10,7 @@ sub call {
     my $self = shift;
     my($env) = @_;
 
-    my $time = Time::HiRes::gettimeofday;
+    my $time = [Time::HiRes::gettimeofday];
     my $length = 0;
     my $logger = $self->logger || sub { $env->{'psgi.errors'}->print(@_) };
 
@@ -29,8 +29,8 @@ sub call {
                 $length += length $line if defined $line;
 
                 unless( defined $line ) {
-                    my $now = Time::HiRes::gettimeofday;
-                    $logger->( $self->log_line($status, $header, $env, { time => $now - $time, content_length => $length }) );
+                    my $now = [Time::HiRes::gettimeofday];
+                    $logger->( $self->log_line($status, $header, $env, { time => scalar Time::HiRes::tv_interval($time, $now) * 1_000_000, content_length => $length }) );
                 }
 
                 return $line;
@@ -48,8 +48,8 @@ sub call {
             close => sub {
                 $body->close if ref $body ne 'ARRAY';
 
-                my $now = Time::HiRes::gettimeofday;
-                $logger->( $self->log_line($status, $header, $env, { time => $now - $time, content_length => $length }) );
+                my $now = [Time::HiRes::gettimeofday];
+                $logger->( $self->log_line($status, $header, $env, { time => scalar Time::HiRes::tv_interval($time, $now) * 1_000_000, content_length => $length }) );
             },
         );
 

--- a/t/Plack-Middleware/access_log_timed.t
+++ b/t/Plack-Middleware/access_log_timed.t
@@ -155,6 +155,7 @@ mock_time {
     like $log, qr@^\d \d{7}@; # around '3 3500000'
 } time();
 
+$log = '';
 mock_time {
     $wait_sec = 0.3;
     $test_req->(GET "http://localhost/");

--- a/t/Plack-Middleware/access_log_timed.t
+++ b/t/Plack-Middleware/access_log_timed.t
@@ -152,13 +152,13 @@ $test_req = sub {
 mock_time {
     $wait_sec = 3.5;
     $test_req->(GET "http://localhost/");
-    like $log, qr@^\d\.\d+ \d{7}@; # around '3.5 3500000'
+    like $log, qr@^\d \d{7}@; # around '3 3500000'
 } time();
 
 mock_time {
     $wait_sec = 0.3;
     $test_req->(GET "http://localhost/");
-    like $log, qr@^\d\.\d+ \d{6}@; # around '0.3 300000'
+    like $log, qr@^\d \d{6}@; # around '0 300000'
 } time();
 
 done_testing;

--- a/t/Plack-Middleware/access_log_timed.t
+++ b/t/Plack-Middleware/access_log_timed.t
@@ -4,6 +4,8 @@ use Test::More;
 use HTTP::Request::Common;
 use Plack::Test;
 use Plack::Builder;
+use Test::MockTime::HiRes qw(mock_time);
+use Time::HiRes;
 
 my $log;
 my $handler = builder {
@@ -121,5 +123,42 @@ $test_req = sub {
     like $log, qr@GET /foo%20bar\?baz=baz HTTP/1\.1@;
 }
 
+# Testing '%D' and '%T'
+
+$log = '';
+my $wait_sec = 1;
+$handler = builder {
+    enable "Plack::Middleware::AccessLog::Timed",
+        logger => sub { $log .= "@_" },
+        format => '%T %D';
+    sub {
+        return sub {
+            Time::HiRes::sleep $wait_sec;
+            $_[0]->( [ 200, [ 'Content-Type' => 'text/plain' ], [ 'OK' ] ] )
+        }
+    };
+};
+
+$test_req = sub {
+    my $req = shift;
+    test_psgi app => $handler,
+        client => sub {
+        my $cb = shift;
+        $cb->($req);
+    };
+};
+
+
+mock_time {
+    $wait_sec = 3.5;
+    $test_req->(GET "http://localhost/");
+    like $log, qr@^\d\.\d+ \d{7}@; # around '3.5 3500000'
+} time();
+
+mock_time {
+    $wait_sec = 0.3;
+    $test_req->(GET "http://localhost/");
+    like $log, qr@^\d\.\d+ \d{6}@; # around '0.3 300000'
+} time();
 
 done_testing;


### PR DESCRIPTION
ref: #549 https://github.com/kazeburo/Apache-LogFormat-Compiler/pull/12

As described at #549, it's necessary to fix both `Plack` and `Apache::LogFormat::Compiler`.
The bug in `Apache::LogFormat::Compiler` is fixed at https://github.com/kazeburo/Apache-LogFormat-Compiler/pull/12 and released as 0.34.