### PR TITLE
Use Plack::App::Directory for directories

### DIFF
--- a/lib/Plack/Runner.pm
+++ b/lib/Plack/Runner.pm
@@ -160,6 +160,13 @@ sub locate_app {
         return sub { $psgi };
     }
 
+    if (-d $psgi) {
+        return sub {
+            require Plack::App::Directory;
+            Plack::App::Directory->new({ root => $psgi })->to_app;
+        };
+    }
+
     if ($self->{eval}) {
         $self->loader->watch("lib");
         return build {

--- a/script/plackup
+++ b/script/plackup
@@ -20,6 +20,9 @@ plackup - Run PSGI application with Plack handlers
   # choose .psgi file from ARGV[0] (or with -a option)
   plackup hello.psgi
 
+  # use directory listing app
+  plackup /tmp
+
   # switch server implementation with --server (or -s)
   plackup --server HTTP::Server::Simple --port 9090 --host 127.0.0.1 test.psgi
 
@@ -59,6 +62,9 @@ application:
 The first non-option argument is used as a C<.psgi> file path. You can
 also set this path with C<-a> or C<--app>. If omitted, the
 default file path is C<app.psgi> in the current directory.
+
+If a directory is used instead of a .psgi file, an instance of
+C<Plack::App::Directory> will be setup with that directory as root.
 
 =back
 


### PR DESCRIPTION
[Looking](http://blogs.perl.org/users/alex_muntada/2016/02/simplest-way-of-serving-local-files-over-http.html) for an easy way to achieve `python -m SimpleHTTPServer` in Perl, I was pointed to `Plack::App::Directory`, which is nice but too much complicated to run from the shell.

So, I tried to find a trivial way to extend plackup to easly serve files from a directory and I came up with this small change that creates a `Plack::App::Directory` instance as the default app when a directory is passed instead of a .psgi file. Now, you just need to run `plackup /path/to/dir` and _voilà_!