### PR TITLE
Allow quoted cookie values, as per RFC 6265

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -73,8 +73,7 @@ sub cookies {
         $key = URI::Escape::uri_unescape($key);
 
         # Values can be quoted
-        $value =~ s/\A"//;
-        $value =~ s/"\z//;
+        $value =~ s/\A"(.*)"\z/$1/;
 
         $value = URI::Escape::uri_unescape($value);
 

--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -68,7 +68,15 @@ sub cookies {
         # trim leading trailing whitespace
         $pair =~ s/^\s+//; $pair =~ s/\s+$//;
 
-        my ($key, $value) = map URI::Escape::uri_unescape($_), split( "=", $pair, 2 );
+        my ($key, $value) = split( "=", $pair, 2 );
+
+        $key = URI::Escape::uri_unescape($key);
+
+        # Values can be quoted
+        $value =~ s/\A"//;
+        $value =~ s/"\z//;
+
+        $value = URI::Escape::uri_unescape($value);
 
         # Take the first one like CGI.pm or rack do
         $results{$key} = $value unless exists $results{$key};

--- a/t/Plack-Request/cookie.t
+++ b/t/Plack-Request/cookie.t
@@ -13,6 +13,11 @@ my $app = sub {
     is $req->cookies->{Bar}, 'Baz';
     is $req->cookies->{XXX}, 'Foo Bar';
     is $req->cookies->{YYY}, 0, "When we get multiple values we return the first one (which e.g. Apache does too)";
+    is $req->cookies->{ZZZ}, 'spaced out';
+    is $req->cookies->{ZZTOP}, '"with quotes"';
+    is $req->cookies->{BOTH}, '"internal quotes"';
+    is $req->cookies->{EMPTYQUOTE}, '';
+    is $req->cookies->{EMPTY}, '';
 
     $req->new_response(200)->finalize;
 };
@@ -20,7 +25,18 @@ my $app = sub {
 test_psgi $app, sub {
     my $cb = shift;
     my $req = HTTP::Request->new(GET => "/");
-    $req->header(Cookie => 'Foo=Bar; Bar=Baz; XXX=Foo%20Bar; YYY=0; YYY=3');
+    $req->header(Cookie => join(' ',
+      'Foo=Bar;',
+      'Bar=Baz;',
+      'XXX=Foo%20Bar;',
+      'YYY=0;',
+      'YYY=3;',
+      'ZZZ="spaced out";',
+      'ZZTOP=%22with%20quotes%22;',
+      'BOTH="%22internal quotes%22";',
+      'EMPTYQUOTE="";',
+      'EMPTY=;'
+    ));
     $cb->($req);
 };
 

--- a/t/Plack-Request/cookie.t
+++ b/t/Plack-Request/cookie.t
@@ -18,6 +18,8 @@ my $app = sub {
     is $req->cookies->{BOTH}, '"internal quotes"';
     is $req->cookies->{EMPTYQUOTE}, '';
     is $req->cookies->{EMPTY}, '';
+    is $req->cookies->{BADSTART}, '"data';
+    is $req->cookies->{BADEND}, 'data"';
 
     $req->new_response(200)->finalize;
 };
@@ -35,7 +37,9 @@ test_psgi $app, sub {
       'ZZTOP=%22with%20quotes%22;',
       'BOTH="%22internal quotes%22";',
       'EMPTYQUOTE="";',
-      'EMPTY=;'
+      'EMPTY=;',
+      'BADSTART="data;',
+      'BADEND=data"',
     ));
     $cb->($req);
 };


### PR DESCRIPTION
The spec says:

  cookie-value      = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )