### PR TITLE
#570 CVE-2016-7401. Remove tests that expects cookie to be delimited by comma

### DIFF
--- a/t/Plack-Request/cookie.t
+++ b/t/Plack-Request/cookie.t
@@ -55,23 +55,4 @@ test_psgi $app, sub {
     $cb->(HTTP::Request->new(GET => "/"));
 };
 
-$app = sub {
-    my $warn = 0;
-    local $SIG{__WARN__} = sub { $warn++ };
-
-    my $req = Plack::Request->new(shift);
-
-    is $req->cookies->{Foo}, 'Bar';
-    is $warn, 0;
-
-    $req->new_response(200)->finalize;
-};
-
-test_psgi $app, sub {
-    my $cb  = shift;
-    my $req = HTTP::Request->new(GET => "/");
-    $req->header(Cookie => 'Foo=Bar,; Bar=Baz;');
-    $cb->($req);
-};
-
 done_testing;


### PR DESCRIPTION
Related #570 

This PR removes tests that  expects cookie to be delimited by comma.
These tests were added in https://github.com/plack/Plack/pull/149 

