### PR TITLE
Add ConditionalGet support to Plack::Middleware::Static

### DIFF
--- a/lib/Plack/Middleware/Static.pm
+++ b/lib/Plack/Middleware/Static.pm
@@ -3,8 +3,9 @@ use strict;
 use warnings;
 use parent qw/Plack::Middleware/;
 use Plack::App::File;
+use Plack::Middleware::ConditionalGET;
 
-use Plack::Util::Accessor qw( path root encoding pass_through content_type );
+use Plack::Util::Accessor qw( path root encoding pass_through content_type conditional_get);
 
 sub call {
     my $self = shift;
@@ -29,7 +30,14 @@ sub _handle_static {
         return unless $matched;
     }
 
-    $self->{file} ||= Plack::App::File->new({ root => $self->root || '.', encoding => $self->encoding, content_type => $self->content_type });
+    $self->{file} ||= do {
+        my $file = Plack::App::File->new({
+            root => $self->root || '.',
+            encoding => $self->encoding,
+            content_type => $self->content_type
+        });
+        $self->conditional_get ? Plack::Middleware::ConditionalGET->new({app => $file}) : $file;
+    };
     local $env->{PATH_INFO} = $path; # rewrite PATH
     return $self->{file}->call($env);
 }
@@ -47,7 +55,8 @@ Plack::Middleware::Static - serve static files with Plack
 
   builder {
       enable "Plack::Middleware::Static",
-          path => qr{^/(images|js|css)/}, root => './htdocs/';
+          path => qr{^/(images|js|css)/}, root => './htdocs/',
+          conditional_get => 1;
       $app;
   };
 
@@ -117,12 +126,20 @@ the request on to the application it is wrapping.
 
 =item content_type
 
-The C<content_type> option can be used to provide access to a different MIME 
+The C<content_type> option can be used to provide access to a different MIME
 database than L<Plack::MIME>.
-L<Plack::MIME> works fast and good for a list of well known file endings, 
+L<Plack::MIME> works fast and good for a list of well known file endings,
 but if you need a more accurate content based checking you can use modules
 like L<File::MimeInfo> or L<File::MMagic> for example.
 The callback should work on $_[0] which is the filename of the file.
+
+=item conditional_get
+
+When this option is set to a true value, this middleware wraps
+L<Plack::Middleware::ConditionalGET> around requests that match a file.
+
+Requests that pass through to the application this middleware is wrapping
+do not have L<Plack::Middleware::ConditionalGET> applied.
 
 =back
 

--- a/t/Plack-Middleware/static.t
+++ b/t/Plack-Middleware/static.t
@@ -18,7 +18,7 @@ my $handler = builder {
         path => sub { s!^/share/!!}, root => "share";
     enable "Plack::Middleware::Static",
         path => sub { s!^/more_share/!! if $_[1]->{PATH_INFO} =~ m!^/more_share/!  },
-        root => "share";
+        root => "share", conditional_get => 1;
     enable "Plack::Middleware::Static",
         path => sub { s!^/share-pass/!!}, root => "share", pass_through => 1;
     enable "Plack::Middleware::Static",
@@ -69,6 +69,12 @@ my %test = (
         {
             my $res = $cb->(GET "http://localhost/more_share/face.jpg");
             is $res->content_type, 'image/jpeg';
+            my $last_modified = $res->headers->header('Last-Modified');
+            $res = $cb->(
+                GET "http://localhost/more_share/face.jpg",
+                'If-Modified-Since' => $last_modified
+            );
+            is $res->code, 304;
         }
 
         {


### PR DESCRIPTION
If you use the pass through feature of Plack::Middleware::Static, its not straight forward to wrap the responses from that middleware with Plack::Middleware::ConditionalGet without also wrapping the inner application.

This PR adds a `conditional_get` attribute to Plack::Middleware::Static. If the `conditional_get` attribute has a true value, the Plack::App::File instance is wrapped with Plack::Middleware::ConditionalGET, allowing `304 Not Modified` responses to be returned for static content; but any requests that pass through to the underlying application are not wrapped by ConditionalGET.

Dancer2 uses the pass through feature of Plack::Middleware::Static. [Issue #1253](https://github.com/PerlDancer/Dancer2/issues/1253) has a feature request for ConditionalGet support for static content.