### PR TITLE
Do not set if TCP_NODELAY is not available

### DIFF
--- a/lib/HTTP/Server/PSGI.pm
+++ b/lib/HTTP/Server/PSGI.pm
@@ -105,8 +105,10 @@ sub accept_loop {
     while (1) {
         local $SIG{PIPE} = 'IGNORE';
         if (my $conn = $self->{listen_sock}->accept) {
-            $conn->setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
-                or die "setsockopt(TCP_NODELAY) failed:$!";
+            if (eval { TCP_NODELAY }) {
+                $conn->setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
+                    or die "setsockopt(TCP_NODELAY) failed:$!";
+            }
             my $env = {
                 SERVER_PORT => $self->{port},
                 SERVER_NAME => $self->{host},

--- a/lib/HTTP/Server/PSGI.pm
+++ b/lib/HTTP/Server/PSGI.pm
@@ -13,10 +13,12 @@ use Plack::Util;
 use Stream::Buffered;
 use Plack::Middleware::ContentLength;
 use POSIX qw(EINTR);
-use Socket qw(IPPROTO_TCP TCP_NODELAY);
+use Socket qw(IPPROTO_TCP);
 
 use Try::Tiny;
 use Time::HiRes qw(time);
+
+use constant TCP_NODELAY => try { Socket::TCP_NODELAY };
 
 my $alarm_interval;
 BEGIN {
@@ -105,7 +107,7 @@ sub accept_loop {
     while (1) {
         local $SIG{PIPE} = 'IGNORE';
         if (my $conn = $self->{listen_sock}->accept) {
-            if (eval { TCP_NODELAY }) {
+            if (defined TCP_NODELAY) {
                 $conn->setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
                     or die "setsockopt(TCP_NODELAY) failed:$!";
             }


### PR DESCRIPTION
Hi,

On Android with [Termux](https://termux.com/) and Perl 5.24.0:

```
u0_a168@localhost:~$ perl -MSocket=TCP_NODELAY -e TCP_NODELAY
Your vendor has not defined Socket macro TCP_NODELAY, used at -e line 1
```

Could you add some workaround, please?
