### PR TITLE
Fix typo on mod_fcgid directive

### DIFF
--- a/lib/Plack/Handler/FCGI.pm
+++ b/lib/Plack/Handler/FCGI.pm
@@ -419,7 +419,7 @@ Apache2 with mod_fastcgi:
 
 mod_fcgid:
 
-  FcgiPassHeader Authorization
+  FcgidPassHeader Authorization
 
 =head2 Server::Starter
 


### PR DESCRIPTION
Ref: https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#FcgidPassHeader

I needed this to make it work for me :-)