### PR TITLE
Lowercase headers before passing to HTTP::Headers::Fast

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -93,7 +93,7 @@ sub headers {
         $self->{headers} = HTTP::Headers::Fast->new(
             map {
                 (my $field = $_) =~ s/^HTTPS?_//;
-                ( $field => $env->{$_} );
+                ( lc($field) => $env->{$_} );
             }
                 grep { /^(?:HTTP|CONTENT)/i } keys %$env
             );


### PR DESCRIPTION
HTTP::Headers::Fast tries to preserve the original case in initializer, but in PSGI they're all in upper-case from the environment. This makes a weird result when you try to print headers as a string or use the scan() method, where all incoming keys are all uppercase.

Because HTTP header field names are case insensitive, this should not really matter, but rather than trying to preserve the all-upper case that is coming from PSGI env, just pass it in lowercase, so that the default casing would just work.