### PR TITLE
Plack::App::WrapCGI: add execution model fork+noexec

### DIFF
--- a/lib/Plack/App/WrapCGI.pm
+++ b/lib/Plack/App/WrapCGI.pm
@@ -52,9 +52,21 @@ sub prepare_app {
                   or Carp::croak "Cannot dup STDIN: $!";
 
                 chdir(File::Basename::dirname($script));
-                exec($script) or Carp::croak("cannot exec: $!");
 
-                exit(2);
+                if ($self->execute eq 'noexec') {
+                    if (!-x $script) {
+                        Carp::croak "$script is not executable";
+                    }
+                    $0 = $script;
+                    if (FindBin->can('again')) {
+                        FindBin->again;
+                    }
+                    do $0; # XXX error handling?
+                    exit(0);
+                } else {
+                    exec($script) or Carp::croak("cannot exec: $!");
+                    exit(2);
+                }
             }
 
             close $stdoutw;

--- a/lib/Plack/App/WrapCGI.pm
+++ b/lib/Plack/App/WrapCGI.pm
@@ -150,9 +150,16 @@ The path to a CGI-style program. This is a required parameter.
 
 =item execute
 
-An optional parameter. When set to a true value, this app will run the script
+An optional parameter. When set to a true value (but not C<noexec>, see below), this app will run the script
 with a CGI-style C<fork>/C<exec> model. Note that you may run programs written
 in other languages with this approach.
+
+If set to C<noexec>, then still a C<fork> is done, but the existing
+perl interpreter context is re-used. This has the advantage that
+global changes in the process are not affecting other requests. On the
+other hand, unlike in the non-C<execute> model, it's still possible to
+have positive effects on response times, especially if modules are
+preloaded in the C<.psgi>.
 
 =back
 

--- a/lib/Plack/App/WrapCGI.pm
+++ b/lib/Plack/App/WrapCGI.pm
@@ -61,7 +61,9 @@ sub prepare_app {
                     if (FindBin->can('again')) {
                         FindBin->again;
                     }
+                    package main;
                     do $0; # XXX error handling?
+                    warn $@ if $@;
                     exit(0);
                 } else {
                     exec($script) or Carp::croak("cannot exec: $!");

--- a/lib/Plack/App/WrapCGI.pm
+++ b/lib/Plack/App/WrapCGI.pm
@@ -62,6 +62,7 @@ sub prepare_app {
                         FindBin->again;
                     }
                     package main;
+                    local $SIG{__DIE__};
                     do $0; # XXX error handling?
                     warn $@ if $@;
                     exit(0);

--- a/t/Plack-Middleware/wrapcgi_exec.t
+++ b/t/Plack-Middleware/wrapcgi_exec.t
@@ -7,6 +7,7 @@ use Plack::App::WrapCGI;
 use IO::File;
 use File::Temp;
 use File::Spec;
+use Cwd 'abs_path';
 
 plan skip_all => $^O if $^O eq "MSWin32";
 
@@ -164,7 +165,7 @@ print \$q->header(-type => "text/plain"), \$result;
 
         my $res = $cb->(GET "http://localhost/?");
         is $res->code, 200;
-        is $res->content, File::Spec->tmpdir . "\nmain\n";
+        is $res->content, abs_path(File::Spec->tmpdir) . "\nmain\n";
     };
 
     undef $tmp;

--- a/t/Plack-Middleware/wrapcgi_exec.t
+++ b/t/Plack-Middleware/wrapcgi_exec.t
@@ -9,6 +9,9 @@ use File::Temp;
 
 plan skip_all => $^O if $^O eq "MSWin32";
 
+for my $execute (1, 'noexec') {
+    note 'Execution model: ' . ($execute eq '1' ? 'fork+exec' : 'fork+noexec');
+
 {
     my $tmp = File::Temp->new(CLEANUP => 1);
     print $tmp <<"...";
@@ -21,7 +24,7 @@ print \$q->header, "Hello ", scalar \$q->param('name'), " counter=", ++\$COUNTER
 
     chmod(oct("0700"), $tmp->filename) or die "Cannot chmod";
 
-    my $app_exec = Plack::App::WrapCGI->new(script => "$tmp", execute => 1)->to_app;
+    my $app_exec = Plack::App::WrapCGI->new(script => "$tmp", execute => $execute)->to_app;
     test_psgi app => $app_exec, client => sub {
         my $cb = shift;
 
@@ -49,7 +52,7 @@ print \$q->header, "Hello " x 10000;
 
     chmod(oct("0700"), $tmp->filename) or die "Cannot chmod";
 
-    my $app_exec = Plack::App::WrapCGI->new(script => "$tmp", execute => 1)->to_app;
+    my $app_exec = Plack::App::WrapCGI->new(script => "$tmp", execute => $execute)->to_app;
     test_psgi app => $app_exec, client => sub {
         my $cb = shift;
 
@@ -73,7 +76,7 @@ print <STDIN>;
 
     chmod(oct("0700"), $tmp->filename) or die "Cannot chmod";
 
-    my $app_exec = Plack::App::WrapCGI->new(script => "$tmp", execute => 1)->to_app;
+    my $app_exec = Plack::App::WrapCGI->new(script => "$tmp", execute => $execute)->to_app;
     test_psgi app => $app_exec, client => sub {
         my $cb = shift;
 
@@ -124,7 +127,7 @@ print \$q->header(-type => "text/plain"), \$result;
 
     chmod(oct("0700"), $tmp->filename) or die "Cannot chmod";
 
-    my $app_exec = Plack::App::WrapCGI->new(script => "$tmp", execute => 1)->to_app;
+    my $app_exec = Plack::App::WrapCGI->new(script => "$tmp", execute => $execute)->to_app;
     test_psgi app => $app_exec, client => sub {
         my $cb = shift;
 
@@ -135,6 +138,8 @@ print \$q->header(-type => "text/plain"), \$result;
 
     undef $tmp;
 };
+
+}
 
 done_testing;
 

--- a/t/Plack-Middleware/wrapcgi_exec.t
+++ b/t/Plack-Middleware/wrapcgi_exec.t
@@ -149,7 +149,7 @@ print \$q->header(-type => "text/plain"), \$result;
 use CGI;
 use FindBin;
 
-my \$result = "\$FindBin::RealBin\n";
+my \$result = "\$FindBin::RealBin\n" . __PACKAGE__ . "\n";
 
 my \$q = CGI->new;
 print \$q->header(-type => "text/plain"), \$result;
@@ -164,7 +164,7 @@ print \$q->header(-type => "text/plain"), \$result;
 
         my $res = $cb->(GET "http://localhost/?");
         is $res->code, 200;
-        is $res->content, File::Spec->tmpdir . "\n";
+        is $res->content, File::Spec->tmpdir . "\nmain\n";
     };
 
     undef $tmp;


### PR DESCRIPTION
This series of commits introduces a new execution model fork+_noexec_ for CGI scripts on PSGI servers. This model is located in between of the existing execution models: like `execute=>1` it does a `fork` before executing the CGI script (so CGI scripts which pollute the perl process context do not affect other requests), and like `execute=>0` it uses the same perl interpreter context as the PSGI server (so one can preload modules for speed).