### PR TITLE
protect WrapCGI against SIGCHLD handlers

### DIFF
--- a/t/Plack-Middleware/wrapcgi_exec.t
+++ b/t/Plack-Middleware/wrapcgi_exec.t
@@ -136,5 +136,31 @@ print \$q->header(-type => "text/plain"), \$result;
     undef $tmp;
 };
 
+# test that SIGCHLD handlers don't interfere
+{
+    my $tmp = File::Temp->new(CLEANUP => 1);
+    print $tmp <<"...";
+#!$^X
+use CGI;
+my \$q = CGI->new;
+print \$q->header, "Hello";
+...
+    close $tmp;
+
+    chmod(oct("0700"), $tmp->filename) or die "Cannot chmod";
+
+    local $SIG{CHLD} = 'IGNORE';
+    my $app_exec = Plack::App::WrapCGI->new(script => "$tmp", execute => 1)->to_app;
+    test_psgi app => $app_exec, client => sub {
+        my $cb = shift;
+
+        my $res = $cb->(GET "http://localhost/");
+        is $res->code, 200;
+        is $res->content, "Hello";
+    };
+
+    undef $tmp;
+};
+
 done_testing;
 


### PR DESCRIPTION
If `$SIG{CHLD}` is set to `'IGNORE'`, or to a "reaper" coderef, `WrapCGI` (in "execute" mode) stalls in a tight loop when the CGI exits, because `waitpid` returns -1 instead of the positive pid it would usually return.

This patch fixes that (and tests that it works)