### PR TITLE
Remove share/#foo

### DIFF
--- a/t/Plack-Middleware/directory.t
+++ b/t/Plack-Middleware/directory.t
@@ -13,6 +13,9 @@ my %test = (
     client => sub {
         my $cb  = shift;
 
+        open my $fh, ">", "share/#foo" or die $!;
+        close $fh;
+
         # URI-escape
         my $res = $cb->(GET "http://localhost/");
         my($ct, $charset) = $res->content_type;
@@ -29,6 +32,8 @@ my %test = (
 
         $res = $cb->(GET "/");
         like $res->content, qr/Index of \//;
+
+        unlink "share/#foo";
 
     SKIP: {
             skip "Filenames can't end with . on windows", 2 if $^O eq "MSWin32";


### PR DESCRIPTION
Fix #591 

As described in #591, `share/#foo` is problematic on StrawberryPerl 5.26.
On the other hand, it is only used in a Plack's own test  t/Plack-Middleware/directory.t.
Thus remove it, and create it only when it is necessary.