### PR TITLE
sanitize %ENV

### DIFF
--- a/lib/Plack/App/WrapCGI.pm
+++ b/lib/Plack/App/WrapCGI.pm
@@ -45,7 +45,13 @@ sub prepare_app {
                 close $stdoutr;
                 close $stdinw;
 
-                local %ENV = (%ENV, CGI::Emulate::PSGI->emulate_environment($env));
+                my %env = %ENV;
+                for (qw(REMOTE_HOST HTTP_AUTHORIZATION IFS CDPATH PATH LD_PRELOAD
+                        LD_TRACE_LOADED_OBJECTS LD_WARN LD_DEBUG LD_AUDIT LD_VERBOSE))
+                {
+                    delete $env{$_};
+                }
+                local %ENV = (%env, CGI::Emulate::PSGI->emulate_environment($env));
 
                 open( STDOUT, ">&=" . fileno($stdoutw) )
                   or Carp::croak "Cannot dup STDOUT: $!";

--- a/lib/Plack/Handler/CGI.pm
+++ b/lib/Plack/Handler/CGI.pm
@@ -88,8 +88,15 @@ sub setup_env {
     binmode STDIN;
     binmode STDERR;
 
+    my %env = %ENV;
+    for (qw(REMOTE_HOST HTTP_AUTHORIZATION IFS CDPATH PATH LD_PRELOAD
+            LD_TRACE_LOADED_OBJECTS LD_WARN LD_DEBUG LD_AUDIT LD_VERBOSE))
+    {
+        delete $env{$_};
+    }
+
     my $env = {
-        %ENV,
+        %env,
         'psgi.version'    => [ 1, 1 ],
         'psgi.url_scheme' => ($ENV{HTTPS}||'off') =~ /^(?:on|1)$/i ? 'https' : 'http',
         'psgi.input'      => *STDIN,


### PR DESCRIPTION
See e.g. for a nice remote CGI exploit via
LD_PRELOAD: https://www.elttam.com.au/blog/goahead/

The env_sanitizer should probably go into a helper function.
That's up to you to decide where to.

I also haven't checked what Apache how does its ENV sanitizing.
I just hope it does.