### PR TITLE
silence warnings under old perls

### DIFF
--- a/lib/Plack/App/URLMap.pm
+++ b/lib/Plack/App/URLMap.pm
@@ -2,7 +2,7 @@ package Plack::App::URLMap;
 use strict;
 use warnings;
 use parent qw(Plack::Component);
-use constant DEBUG => $ENV{PLACK_URLMAP_DEBUG};
+use constant DEBUG => $ENV{PLACK_URLMAP_DEBUG} ? 1 : 0;
 
 use Carp ();
 


### PR DESCRIPTION
Currently `plackup -e 'sub { [200,[],["ok"]] }'` emits warnings under old perls
```
❯ perl -v
This is perl, v5.8.1 built for darwin-2level
...

❯ plackup -e 'sub {[200,[],["ok"]]}'
Useless use of a constant in void context at /Users/skaji/env/plenv/versions/5.8.1/lib/perl5/site_perl/5.8.1/Plack/App/URLMap.pm line 55.
Useless use of a constant in void context at /Users/skaji/env/plenv/versions/5.8.1/lib/perl5/site_perl/5.8.1/Plack/App/URLMap.pm line 61.
Useless use of a constant in void context at /Users/skaji/env/plenv/versions/5.8.1/lib/perl5/site_perl/5.8.1/Plack/App/URLMap.pm line 74.
HTTP::Server::PSGI: Accepting connections at http://0:5000/
```

I would be nice if Plack silences these warnings.