### PR TITLE
plackup: Check the default path of watch exists

### DIFF
--- a/lib/Plack/Runner.pm
+++ b/lib/Plack/Runner.pm
@@ -161,7 +161,7 @@ sub locate_app {
     }
 
     if ($self->{eval}) {
-        $self->loader->watch("lib");
+        $self->loader->watch("lib") if -e "lib";
         return build {
             no strict;
             no warnings;
@@ -175,7 +175,9 @@ sub locate_app {
     $psgi ||= "app.psgi";
 
     require File::Basename;
-    $self->loader->watch( File::Basename::dirname($psgi) . "/lib", $psgi );
+    my $lib = File::Basename::dirname($psgi) . "/lib";
+    $self->loader->watch($lib) if -e $lib;
+    $self->loader->watch($psgi);
     build { Plack::Util::load_psgi $psgi };
 }
 


### PR DESCRIPTION
Filesys::Notify::Simple 0.13 with Linux::Inotify2 dies when passed nonexistent path.
This behavior was instroduced in https://github.com/miyagawa/Filesys-Notify-Simple/pull/21 .

`plackup` adds some paths to watch paths implicitly, that causes problems like below:

* `plackup -R /path/to/watch /path/to/app.psgi` dies when the `lib` directory does not exist in same directory of psgi file
* `plackup -R /path/to/watch -e 'sub { ... }'` dies when the `lib` directory does not exist in current directory
