### PR TITLE
Require File::ShareDir::Install 0.13

### DIFF
--- a/META.json
+++ b/META.json
@@ -46,6 +46,7 @@
             "Devel::StackTrace" : "1.23",
             "Devel::StackTrace::AsHTML" : "0.11",
             "File::ShareDir" : "1.00",
+            "File::ShareDir::Install" : "0.13",
             "Filesys::Notify::Simple" : "0",
             "HTTP::Entity::Parser" : "0.17",
             "HTTP::Headers::Fast" : "0.18",

--- a/cpanfile
+++ b/cpanfile
@@ -4,6 +4,7 @@ requires 'Cookie::Baker', '0.07';
 requires 'Devel::StackTrace', '1.23';
 requires 'Devel::StackTrace::AsHTML', '0.11';
 requires 'File::ShareDir', '1.00';
+requires 'File::ShareDir::Install', '0.13';
 requires 'Filesys::Notify::Simple';
 requires 'HTTP::Message', '5.814';
 requires 'HTTP::Headers::Fast', '0.18';


### PR DESCRIPTION
File::ShareDir::Install is used in Makefile.PL:9 but not listed as a dependency 