### PR TITLE
restarter validity regexp

### DIFF
--- a/lib/Plack/Loader/Restarter.pm
+++ b/lib/Plack/Loader/Restarter.pm
@@ -54,7 +54,7 @@ sub valid_file {
     }
     $file->{path} !~ m!\.(?:git|svn)[/\\]             # VCS repositories
                       |\.(?:bak|swp|swpx|swx)$        # tmp/backup extensions
-                      |~$                             # ditto, not an extension
+                      |[~#]$                          # ditto, not an extension
                       |_flymake\.p[lm]$
                       |\.#
                       !x;

--- a/lib/Plack/Loader/Restarter.pm
+++ b/lib/Plack/Loader/Restarter.pm
@@ -52,7 +52,12 @@ sub valid_file {
     if ( $file->{path} =~ m{(\d+)$} && $1 >= 4913 && $1 <= 5036) {
         return 0;
     }
-    $file->{path} !~ m!\.(?:git|svn)[/\\]|\.(?:bak|swp|swpx|swx)$|~$|_flymake\.p[lm]$|\.#!;
+    $file->{path} !~ m!\.(?:git|svn)[/\\]             # VCS repositories
+                      |\.(?:bak|swp|swpx|swx)$        # tmp/backup extensions
+                      |~$                             # ditto, not an extension
+                      |_flymake\.p[lm]$
+                      |\.#
+                      !x;
 }
 
 sub run {

--- a/lib/Plack/Loader/Restarter.pm
+++ b/lib/Plack/Loader/Restarter.pm
@@ -53,7 +53,7 @@ sub valid_file {
         return 0;
     }
     $file->{path} !~ m!\.(?:git|svn)[/\\]             # VCS repositories
-                      |\.(?:bak|swp|swpx|swx)$        # tmp/backup extensions
+                      |\.(?:bak|save|swp|swpx|swx)$   # tmp/backup extensions
                       |[~#]$                          # ditto, not an extension
                       |_flymake\.p[lm]$
                       |\.#


### PR DESCRIPTION
A couple of editors' temp files were causing plackup -R to restart too frequently.