### PR TITLE
Fix typo in doc of Plack::Util

### DIFF
--- a/lib/Plack/Util.pm
+++ b/lib/Plack/Util.pm
@@ -556,7 +556,7 @@ object for input or errors.
 
 =item encode_html
 
-  my $encoded_string = Plack::Util::encode( $string );
+  my $encoded_string = Plack::Util::encode_html( $string );
 
 Entity encodes C<<>, C<< > >>, C<&>, C<"> and C<'> in the input string
 and returns it.


### PR DESCRIPTION
The doc of `encode_html` had typo