### PR TITLE
Add "use Test::More;" to the SYNOPSIS of Plack::Test

### DIFF
--- a/lib/Plack/Test.pm
+++ b/lib/Plack/Test.pm
@@ -50,6 +50,7 @@ Plack::Test - Test PSGI applications with various backends
 
   use Plack::Test;
   use HTTP::Request::Common;
+  use Test::More;
 
   # Simple OO interface
   my $app = sub { return [ 200, [], [ "Hello" ] ] };


### PR DESCRIPTION
Just a suggestion to add one line "use Test::More;" to the SYNOPSIS of Plack::Test.
After reading the docs I wrongly assumed that Plack::Test would export these functions itself.  It is ok that it doesn't, the line in the synopsis points it out.

Cheers,
haj (just another happy Plack user)