### PR TITLE
Convert hello.py to Python 3

### DIFF
--- a/t/Plack-Middleware/cgi-bin/hello.py
+++ b/t/Plack-Middleware/cgi-bin/hello.py
@@ -1,9 +1,9 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import os
 
-print "Content-Type: text/plain"
+print("Content-Type: text/plain")
 print
 for item in ([ "foo", "bar" ]):
-    print "Hello " + item + ". "
+    print("Hello " + item + ". ")
 
-print "QUERY_STRING is " + os.environ['QUERY_STRING']
+print("QUERY_STRING is " + os.environ['QUERY_STRING'])

--- a/t/Plack-Middleware/cgi-bin/hello.py
+++ b/t/Plack-Middleware/cgi-bin/hello.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/python
+from __future__ import print_function
 import os
 
 print("Content-Type: text/plain")

--- a/t/Plack-Middleware/cgibin_exec.t
+++ b/t/Plack-Middleware/cgibin_exec.t
@@ -7,12 +7,8 @@ use Plack::Test;
 use HTTP::Request::Common;
 use Plack::App::CGIBin;
 
-unless (-e "/usr/bin/python" && -x _) {
-    plan skip_all => "You don't have /usr/bin/python";
-}
-
-if (`/usr/bin/python --version 2>&1` =~ /^Python 3/) {
-    plan skip_all => "This test doesn't support python 3 yet";
+unless (-e "/usr/bin/python3" && -x _) {
+    plan skip_all => "You don't have /usr/bin/python3";
 }
 
 my $app = Plack::App::CGIBin->new(root => "t/Plack-Middleware/cgi-bin")->to_app;

--- a/t/Plack-Middleware/cgibin_exec.t
+++ b/t/Plack-Middleware/cgibin_exec.t
@@ -7,8 +7,8 @@ use Plack::Test;
 use HTTP::Request::Common;
 use Plack::App::CGIBin;
 
-unless (-e "/usr/bin/python3" && -x _) {
-    plan skip_all => "You don't have /usr/bin/python3";
+unless (-e "/usr/bin/python" && -x _) {
+    plan skip_all => "You don't have /usr/bin/python";
 }
 
 my $app = Plack::App::CGIBin->new(root => "t/Plack-Middleware/cgi-bin")->to_app;


### PR DESCRIPTION
Support for Python 2 will end on 2020-01-01. Given this, it make sense to move t/Plack-Middleware/cgi-bin/hello.py to use Python 3 instead.