### PR TITLE
Fixes redirect loop if PATH_INFO is empty string

### DIFF
--- a/lib/Plack/App/Directory.pm
+++ b/lib/Plack/App/Directory.pm
@@ -63,7 +63,7 @@ sub serve_path {
         return $self->SUPER::serve_path($env, $dir, $fullpath);
     }
 
-    my $dir_url = $env->{SCRIPT_NAME} . $env->{PATH_INFO};
+    my $dir_url = ( $env->{SCRIPT_NAME} . $env->{PATH_INFO} or '/' );
 
     if ($dir_url !~ m{/$}) {
         return $self->return_dir_redirect($env);


### PR DESCRIPTION
https://metacpan.org/pod/PSGI#The-Environment states that PATH_INFO may be an empty string.

Resolves plack#637.