### PR TITLE
Add --listen-sock option

### DIFF
--- a/t/Plack-Runner/options.t
+++ b/t/Plack-Runner/options.t
@@ -1,27 +1,39 @@
 use Test::More;
 use Plack::Runner;
 
+use IO::Socket::INET;
+
 sub p {
     my $r = Plack::Runner->new;
     $r->parse_options(@_);
     return {@{$r->{options}}};
 }
 
-my %defaults = ( host => undef, port => 5000, listen => [ ':5000' ], socket => undef );
+my %defaults = ( host => undef, port => 5000, listen => [ ':5000' ], listen_sock => undef, socket => undef );
 
 is_deeply p(), { %defaults };
 is_deeply p('-l', '/tmp/foo.sock'),
-    { host => undef, port => undef, listen => [ '/tmp/foo.sock' ], socket => '/tmp/foo.sock' };
+    { host => undef, port => undef, listen => [ '/tmp/foo.sock' ], listen_sock => undef, socket => '/tmp/foo.sock' };
 is_deeply p('-o', '0.0.0.0', '--port', 9000),
-    { host => '0.0.0.0', port => 9000, listen => [ '0.0.0.0:9000' ], socket => undef };
+    { host => '0.0.0.0', port => 9000, listen => [ '0.0.0.0:9000' ], listen_sock => undef, socket => undef };
 is_deeply p('-S', 'foo.sock'),
-    { host => undef, port => undef, listen => [ 'foo.sock' ], socket => 'foo.sock' };
+    { host => undef, port => undef, listen => [ 'foo.sock' ], listen_sock => undef, socket => 'foo.sock' };
 is_deeply p('-l', ':80'),
-    { host => undef, port => 80, listen => [ ':80' ], socket => undef };
+    { host => undef, port => 80, listen => [ ':80' ], listen_sock => undef, socket => undef };
 is_deeply p('-l', '10.0.0.1:80', '-l', 'unix.sock'),
-    { host => '10.0.0.1', port => 80, listen => [ '10.0.0.1:80', 'unix.sock' ], socket => 'unix.sock' };
+    { host => '10.0.0.1', port => 80, listen => [ '10.0.0.1:80', 'unix.sock' ], listen_sock => undef, socket => 'unix.sock' };
 is_deeply p('-l', ':80', '--disable-foo', '--enable-bar'),
-    { host => undef, port => 80, listen => [ ':80' ], socket => undef, foo => '', bar => 1 };
+    { host => undef, port => 80, listen => [ ':80' ], listen_sock => undef, socket => undef, foo => '', bar => 1 };
+
+
+$sock = IO::Socket::INET->new(
+    LocalAddr => 'localhost',
+    LocalPort => 0,
+    Proto     => 'tcp',
+);
+
+is_deeply p('--listen-sock', $sock),
+    { host => undef, port => undef, listen => [ ], listen_sock => $sock, socket => undef };
 
 {
     my $r = Plack::Runner->new;


### PR DESCRIPTION
This allows passing in a socket object, for example

```perl
$sock = IO::Socket::INET->new(
    LocalAddr => 'localhost',
    LocalPort => 0,
    Proto     => 'tcp',
);
$runner->parse_options('--listen-sock', $sock);
```

The option will get passed down to HTTP::Server::PSGI

https://github.com/plack/Plack/blob/master/lib/HTTP/Server/PSGI.pm#L40-L43

I need this because I want to ensure Plack::Runner is running on a free port, but I don't think there's a way to do that currently (that's guaranteed to be free from race conditions). What I'd like to be able to do is

```perl
my $server = Test::TCP->new(
    listen => 1,
    code => sub {
        my $socket = shift;
        my $sock_fd = fileno($socket);
        my $app = ...;
        my $runner = Plack::Runner->new;
        $runner->parse_options('--listen-sock', $sock);
        $runner->run($app);
    }
);
my $port = $server->port;
```