### PR TITLE
Fixed typo in middleware pod

### DIFF
--- a/lib/Plack/Middleware.pm
+++ b/lib/Plack/Middleware.pm
@@ -103,7 +103,7 @@ middleware.
   sub call {
       my($self, $env) = @_;
       # pre-processing $env
-      my $res = $app->($env);
+      my $res = $self->app->($env);
 
       return Plack::Util::response_cb($res, sub {
           my $res = shift;


### PR DESCRIPTION
Whilst writing my own post processing middleware, I used the example in the pod as a base and kept getting the following error (running in strict mode):

```
Can't use an undefined value as a subroutine reference at lib/Plack/Middleware/PDF.pm line 8
```

My initial module code was:

```
package Plack::Middleware::PDF;
use Plack::Util;
use parent qw( Plack::Middleware );

sub call {
    my($self, $env) = @_;
    # pre-processing $env
    my $res = $app->($env);

    return Plack::Util::response_cb($res, sub {
        my $res = shift;
        # do something with $res;
    });
}

1;
```

Which is a copy of what's in these docs.

The problem comes from `my $res = $app->($env);` which should be `my $res = $self->app->($env);`. Which is how it is in all the other examples in this file other than the one I use.

Thanks