### PR TITLE
fix HTTP::Message::PSGI handling a delayed writer with no content

### DIFF
--- a/lib/HTTP/Message/PSGI.pm
+++ b/lib/HTTP/Message/PSGI.pm
@@ -137,8 +137,9 @@ sub _res_from_psgi {
     };
 
     if (!defined $body) {
+        $body = [];
         my $o = Plack::Util::inline_object
-            write => sub { push @{ $body ||= [] }, @_ },
+            write => sub { push @$body, @_ },
             close => $convert_resp;
 
         return $o;

--- a/t/HTTP-Message-PSGI/empty_delayed_writer.t
+++ b/t/HTTP-Message-PSGI/empty_delayed_writer.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More;
+use HTTP::Message::PSGI;
+use HTTP::Request;
+use HTTP::Response;
+
+my $app = sub {
+  my ($env) = @_;
+  return sub {
+    my ($responder) = @_;
+    my $writer = $responder->([ 200, [] ]);
+    $writer->close;
+  };
+};
+
+my $env = req_to_psgi(HTTP::Request->new(POST => "http://localhost/post", [ ], 'hello'));
+
+my $response = HTTP::Response->from_psgi($app->($env));
+
+is($response->content, '', 'delayed writer without write gives empty content');
+
+done_testing;


### PR DESCRIPTION
If a delayed writer is used, but ->write is never called, the body
arrayref would never get created, leading to errors.