### PR TITLE
fix a bug with Request body access when Content-Type is empty

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -16,7 +16,7 @@ requires 'URI', '1.59';
 requires 'parent';
 requires 'Apache::LogFormat::Compiler', '0.33';
 requires 'HTTP::Tiny', 0.034;
-requires 'HTTP::Entity::Parser', 0.17;
+requires 'HTTP::Entity::Parser', 0.25;
 requires 'WWW::Form::UrlEncoded', 0.23;
 
 on test => sub {

--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -251,11 +251,6 @@ sub _buffer_length_for {
 
 sub _parse_request_body {
     my $self = shift;
-    if ( !$self->env->{CONTENT_TYPE} ) {
-        $self->env->{'plack.request.body_parameters'} = [];
-        $self->env->{'plack.request.upload'} = Hash::MultiValue->new();
-        return;
-    }
 
     my ($params,$uploads) = $self->request_body_parser->parse($self->env);
     $self->env->{'plack.request.body_parameters'} = $params;

--- a/t/Plack-Request/body-unbuffered.t
+++ b/t/Plack-Request/body-unbuffered.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use Test::More;
+use Plack::Test;
+use Plack::Request;
+use Plack::Util;
+use HTTP::Request::Common;
+
+my $app = sub {
+    my $env = shift;
+
+    $env->{'psgix.input.buffered'} = 0;
+
+    my $input = $env->{'psgi.input'};
+    $env->{'psgi.input'} = Plack::Util::inline_object
+      read => sub { $input->read(@_) };
+    
+    my $req = Plack::Request->new($env);
+    is $req->content, '{}';
+
+    $req->new_response(200)->finalize;
+};
+
+test_psgi $app, sub {
+    my $cb = shift;
+
+    # empty Content-Type
+    my $req = POST "/";
+    $req->content_type("");
+    $req->content("{}");
+    $req->content_length(2);
+
+    my $res = $cb->($req);
+    ok $res->is_success or diag $res->as_string;
+};
+
+done_testing;


### PR DESCRIPTION
fixes #655 

Bump HTTP::Entity::Parser dependency to handle empty Content-Type as an octet-stream blob, and skip short-circuiting when Content-Type is empty inside Plack::Request as well.
