### PR TITLE
Support restricting request methods for static files and add OPTIONS support

### DIFF
--- a/t/Plack-Middleware/static-methods.t
+++ b/t/Plack-Middleware/static-methods.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+use Test::More;
+use Plack::Middleware::Static;
+use Plack::Builder;
+use Plack::Util;
+use HTTP::Request::Common;
+use HTTP::Response;
+use Cwd;
+use Plack::Test;
+
+my $base = cwd;
+
+Plack::MIME->add_type(".foo" => "text/x-fooo");
+
+my $handler = builder {
+    enable "Plack::Middleware::Static",
+        path => sub { s!^/share/!!},
+        root => "share",
+        methods => [qw/ GET HEAD /];
+    sub {
+        [200, ['Content-Type' => 'text/plain', 'Content-Length' => 2], ['ok']]
+    };
+};
+
+my %test = (
+    client => sub {
+        my $cb  = shift;
+
+
+        {
+            my $res = $cb->(GET "http://localhost/share/face.jpg");
+            is $res->content_type, 'image/jpeg';
+        }
+
+        {
+            my $res = $cb->(HEAD "http://localhost/share/face.jpg");
+            is $res->content_type, 'image/jpeg';
+        }
+
+        {
+            my $res = $cb->(POST "http://localhost/share/face.jpg");
+            is $res->code, 405;
+        }
+
+},
+    app => $handler,
+);
+
+test_psgi %test;
+
+done_testing;


### PR DESCRIPTION
This modifies Plack::App::File to support restricting the allowed request methods. If these are set, then it will reject other request methods with HTTP 405.

If it receives an OPTIONS request (assuming it is an allowed method), then it will return a simple OPTIONS response (without CORS support).

This also modifies the Static middleware to pass through the methods attribute to Plack::App::File.

Note that I consider Plack::App::File to be the proper place for handling OPTIONS requests, since it knows about the resource.

CORS support is not added here, since that can be handled with other packages.

This closes #660.