### PR TITLE
Restrict Plack::App::File request methods, GH#660

### DIFF
--- a/lib/Plack/App/File.pm
+++ b/lib/Plack/App/File.pm
@@ -19,6 +19,9 @@ sub call {
     my $self = shift;
     my $env  = shift;
 
+    my $method = $env->{REQUEST_METHOD};
+    return $self->return_405 unless $method eq 'GET' || $method eq 'HEAD';
+
     my($file, $path_info) = $self->file || $self->locate_file($env);
     return $file if ref $file eq 'ARRAY';
 
@@ -110,6 +113,11 @@ sub serve_path {
         ],
         $fh,
     ];
+}
+
+sub return_405 {
+    my $self = shift;
+    return [405, ['Content-Type' => 'text/plain', 'Content-Length' => 18], ['Method Not Allowed']];
 }
 
 sub return_403 {

--- a/t/Plack-Middleware/static.t
+++ b/t/Plack-Middleware/static.t
@@ -88,6 +88,12 @@ my %test = (
             my $res = $cb->(GET "http://localhost/t/Plack-Middleware/static.foo");
             is $res->content_type, 'text/x-foo';
         }
+
+        {
+            my $res = $cb->(POST "http://localhost/more_share/face.jpg");
+            is $res->code, 405, 'not allowed';
+            is $res->content, 'Method Not Allowed';
+        }
 },
     app => $handler,
 );


### PR DESCRIPTION
Static file requests (handled by Plack::App::File, which is used
by Plack::Middleware::Static) were allowing any request method,
including POST or DELETE.

This change only allows GET and HEAD requests. Other requests
will receive a HTTP 405 error.

Fixes #660.