### PR TITLE
Plack::Util::load_psgi: guard against hitting the identifier length limit

### DIFF
--- a/t/Plack-Util/load.t
+++ b/t/Plack-Util/load.t
@@ -67,4 +67,12 @@ use Test::More;
     chdir $cwd;
 }
 
+{
+    local $@;
+    # must be at least 250 characters long
+    my $very_long_path = join '/', map 1..300, 'very_long.psgi';
+    eval { Plack::Util::load_psgi($very_long_path) };
+    unlike($@, qr/Identifier too long/);
+}
+
 done_testing;


### PR DESCRIPTION
When Plack is asked to load a path with a psgi app inside,
ala /foo/bar/app.psgi, it first generates a namespace for
the file -- something like Plack::Sandbox::_2ffoo_2fbar_2fapp_2epsgi.

Those "sandboxed" namespaces can get very long.  Long enough
that they hit Perl's identifier limit of ~250 characters
(see https://perldoc.perl.org/perldiag#Identifier-too-long).

This commit patches Plack::Util::load_psgi()
that always generates paths shorter than the threshold,
and jumps through some hoops to ensure that no two
applications end up sharing namespaces after the trimming.