### PR TITLE
Plack::Middleware::ConditionalGET only check if HTTP 200 [Bug Fix]

### DIFF
--- a/lib/Plack/Middleware/ConditionalGET.pm
+++ b/lib/Plack/Middleware/ConditionalGET.pm
@@ -12,7 +12,7 @@ sub call {
 
     $self->response_cb($res, sub {
         my $res = shift;
-
+        return unless $res->[0] == 200;
         my $h = Plack::Util::headers($res->[1]);
 
         # check both ETag and If-Modified-Since, and at least one should exist

--- a/t/Plack-Middleware/conditionalget.t
+++ b/t/Plack-Middleware/conditionalget.t
@@ -21,6 +21,12 @@ my @tests = (
         headers => [ ETag => $tag ],
     },
     {
+        app => sub { [ 404, [ 'ETag' => $tag, 'Content-Type' => 'text/plain' ], [ 'Not Found' ] ] },
+        env => { REQUEST_METHOD => "GET", HTTP_IF_NONE_MATCH => $tag },
+        status => 404,
+        headers => [ ETag => $tag, 'Content-Type' => 'text/plain' ],
+    },
+    {
         app => sub { [ 200, [ 'Last-Modified' => $date, 'Content-Type' => 'text/plain' ], [ 'OK' ] ] },
         env => { REQUEST_METHOD => "GET", HTTP_IF_MODIFIED_SINCE => $date },
         status => 304,
@@ -80,8 +86,3 @@ for my $block (@tests) {
     is $res->[0], $block->{status};
     is_deeply $res->[1], $block->{headers};
 }
-
-
-
-
-


### PR DESCRIPTION
RFC 2616 Sec 14.25 states that:

> If the request would normally result in anything other than a
> 200 (OK) status, ... the response is exactly the same as for
> a normal GET.

There is no point in checking the headers if the status code is
something else.