### PR TITLE
show warnings if enable/enable_if is called on non-void context

### DIFF
--- a/lib/Plack/Builder.pm
+++ b/lib/Plack/Builder.pm
@@ -109,9 +109,13 @@ sub builder(&) {
         $urlmap;
     };
     local $_add = sub {
+        defined wantarray
+            or Carp::carp("WARNING: You used enable() on non-void context");
         $self->add_middleware(@_);
     };
     local $_add_if = sub {
+        defined wantarray
+            or Carp::carp("WARNING: You used enable_if() on non-void context");
         $self->add_middleware_if(@_);
     };
 


### PR DESCRIPTION
Example: the following code looks like the correct code, but in fact, it mistakenly uses a comma as a semicolon.
```perl
builder {
     enable 'ReverseProxy';
     enable 'Session::Cookie',
         session_key => 'session',
         expires     => 3600,
         secret      => 'mysecret', # incorrect: should be terminated by ;
     enable 'Static',
         path => qr!^/assets/!,
         root => './assets/';
     $app;
};
```

It expect to see errors and warnings, but in fact this code has the correct syntax for Perl, so no errors or warnings will be shown.
The following is the result of B::Deparse on this code:
```perl
&builder(sub {
    enable('ReverseProxy');
    enable('Session::Cookie', 'session_key', 'session', 'expires', 3600, 'secret', 'mysecret', enable('Static', 'path', qr"^/assets/", 'root', './assets/'));
    $app;
})
```

To warning such a mistake, how about displaying warnings like this patch when enable/enable_if is called on void context?
I think enable/enable_if should be called in a void context in general.

related blog entry (Japanese): https://memo.sugyan.com/entry/2021/08/23/003752