### PR TITLE
Set `verify_SSL=>1` by default for HTTP::Tiny in Plack::LWPish

### DIFF
--- a/lib/Plack/LWPish.pm
+++ b/lib/Plack/LWPish.pm
@@ -8,7 +8,7 @@ use Hash::MultiValue;
 sub new {
     my $class = shift;
     my $self  = bless {}, $class;
-    $self->{http} = @_ == 1 ? $_[0] : HTTP::Tiny->new(@_);
+    $self->{http} = @_ == 1 ? $_[0] : HTTP::Tiny->new(verify_SSL => 1, @_);
     $self;
 }
 


### PR DESCRIPTION
HTTP::Tiny doesn't verify TLS/SSL certificates by default. This PR sets that flag for the default user agent so HTTPS certificates are verified like LWP does.

Current (insecure) Plack::LWPish behaviour:
```
$ perl -Ilib -MPlack::LWPish -MHTTP::Request -E 'say Plack::LWPish->new->request(HTTP::Request->new("GET","https://self-signed.badssl.com"))->content'
<!DOCTYPE html>
[..]
```

Compared to LWP:
```
$ perl -MLWP::UserAgent -E 'say LWP::UserAgent->new->request(HTTP::Request->new("GET","https://self-signed.badssl.com"))->content'                                                                                                    
Can't connect to self-signed.badssl.com:443 (certificate verify failed)
```

With this fix applied, certificates are checked and the request fails:
```
$ perl -Ilib -MPlack::LWPish -MHTTP::Request -E 'say Plack::LWPish->new->request(HTTP::Request->new("GET","https://self-signed.badssl.com"))->content'
SSL connection failed for self-signed.badssl.com: SSL connect attempt failed error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed
```

Discussions in Debian that motivated this: 
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=954089
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962407