### PR TITLE
Plack::Request restore/allow default parsing of application/json bodies with HTTP::Entity::Parser

### DIFF
--- a/lib/Plack/Request.pm
+++ b/lib/Plack/Request.pm
@@ -233,6 +233,7 @@ sub _build_body_parser {
     my $parser = HTTP::Entity::Parser->new(buffer_length => $len);
     $parser->register('application/x-www-form-urlencoded', 'HTTP::Entity::Parser::UrlEncoded');
     $parser->register('multipart/form-data', 'HTTP::Entity::Parser::MultiPart');
+    $parser->register('application/json','HTTP::Entity::Parser::JSON');
 
     $parser;
 }

--- a/t/Plack-Request/json_body.t
+++ b/t/Plack-Request/json_body.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+use Plack::Test;
+use Plack::Request;
+use HTTP::Request::Common;
+use JSON::PP;
+
+my $app = sub {
+    my $req = Plack::Request->new(shift);
+    is_deeply $req->body_parameters, { foo => 'bar' };
+    is $req->content, '{"foo":"bar"}';
+    $req->new_response(200)->finalize;
+};
+
+test_psgi $app, sub {
+    my $cb = shift;
+    my $res = $cb->(POST "/", 'Content-Type' => 'application/json', Content => JSON::PP->new->encode({ foo => "bar" }));
+    ok $res->is_success;
+};
+
+done_testing;


### PR DESCRIPTION
register HTTP::Entiry::Parser::JSON in Plack::Request to support JSON body parsing for ->body_parameters, for content-type application/json, similarly to HTTP::Body
