### PR TITLE
Plack::App::File check REQUEST_METHOD after locating file

### DIFF
--- a/lib/Plack/App/File.pm
+++ b/lib/Plack/App/File.pm
@@ -19,11 +19,11 @@ sub call {
     my $self = shift;
     my $env  = shift;
 
-    my $method = $env->{REQUEST_METHOD};
-    return $self->return_405 unless $method eq 'GET' || $method eq 'HEAD';
-
     my($file, $path_info) = $self->file || $self->locate_file($env);
     return $file if ref $file eq 'ARRAY';
+
+    my $method = $env->{REQUEST_METHOD};
+    return $self->return_405 unless $method eq 'GET' || $method eq 'HEAD';
 
     if ($path_info) {
         $env->{'plack.file.SCRIPT_NAME'} = $env->{SCRIPT_NAME} . $env->{PATH_INFO};

--- a/t/Plack-Middleware/static.t
+++ b/t/Plack-Middleware/static.t
@@ -24,7 +24,7 @@ my $handler = builder {
     enable "Plack::Middleware::Static",
         path => qr{\.(t|PL|txt)$}i, root => '.';
     enable "Plack::Middleware::Static",
-        path => qr{\.foo$}i, root => '.', 
+        path => qr{\.foo$}i, root => '.',
         content_type => sub { substr Plack::MIME->mime_type($_[0]),0,-1  } ;
     sub {
         [200, ['Content-Type' => 'text/plain', 'Content-Length' => 2], ['ok']]
@@ -74,6 +74,12 @@ my %test = (
         {
             my $res = $cb->(GET "http://localhost/share-pass/faceX.jpg");
             is $res->code, 200, 'pass through';
+            is $res->content, 'ok';
+        }
+
+        {
+            my $res = $cb->(POST "http://localhost/share-pass/faceX.jpg");
+            is $res->code, 200, 'pass through (POST)';
             is $res->content, 'ok';
         }
 


### PR DESCRIPTION
If the static middleware is used with the pass_through option, then
other request methods (such as POST) will fail.

This fixes that bug introduced in f2d220e90a25597363801eb92e6f37bc35807218 and fixes #682 