### PR TITLE
Plack::Middleware::XSendfile ignore HEAD requests #688

### DIFF
--- a/lib/Plack/Middleware/XSendfile.pm
+++ b/lib/Plack/Middleware/XSendfile.pm
@@ -16,6 +16,7 @@ sub call {
         my $res = shift;
         my($status, $headers, $body) = @$res;
         return unless defined $body;
+        return if $env->{REQUEST_METHOD} eq 'HEAD';
 
         if (Scalar::Util::blessed($body) && $body->can('path')) {
             my $type = $self->_variation($env) || '';

--- a/t/Plack-Middleware/xsendfile.t
+++ b/t/Plack-Middleware/xsendfile.t
@@ -28,6 +28,11 @@ test_psgi app => $handler, client => sub {
         is $res->content, '';
         is $res->header('Content-Length'), 0, 'Content-Length 0';
     }
+
+    {
+        my $res = $cb->(HEAD "http://localhost/t/test.txt", 'X-Sendfile-Type' => 'X-Sendfile');
+        ok !$res->header('X-Sendfile'), 'no pass through app header for HEAD requests';
+    }
 };
 
 test_psgi(


### PR DESCRIPTION
This closes #688 by not setting the X-Sendfile header for HEAD requests.