### PR TITLE
Run cleanup handers first, then post processing

### DIFF
--- a/lib/Plack/Handler/FCGI.pm
+++ b/lib/Plack/Handler/FCGI.pm
@@ -162,8 +162,6 @@ sub run {
         # the request is done
         $request->Finish;
 
-        $proc_manager && $proc_manager->pm_post_dispatch();
-
         # When the fcgi-manager exits it sends a TERM signal to the workers.
         # However, if we're busy processing the cleanup handlers, testing
         # shows that the worker doesn't actually exit in that case.
@@ -175,6 +173,8 @@ sub run {
                 $handler->($env);
             }
         }
+
+        $proc_manager && $proc_manager->pm_post_dispatch();
 
         if ($proc_manager && $env->{'psgix.harakiri.commit'}) {
             $proc_manager->pm_exit("safe exit with harakiri");


### PR DESCRIPTION
The [FCGI::ProcManager `pm_post_dispatch` method](https://metacpan.org/dist/FCGI-ProcManager/source/lib/FCGI/ProcManager.pm#L504-520) may exit if it got a signal.  Currently that will exit before handling the cleanup handlers.  This is similar to harakiri, and the [PSGI::Extensions documentation](https://metacpan.org/pod/PSGI::Extensions) suggests that "it SHOULD [be implemented] in a way that cleanup handlers run before harakiri".  Moving the cleanup handlers before the call to `pm_post_dispatch` should behave more correctly.