### PR TITLE
Add support for a dir_index option

### DIFF
--- a/lib/Plack/App/Directory.pm
+++ b/lib/Plack/App/Directory.pm
@@ -3,6 +3,7 @@ use parent qw(Plack::App::File);
 use strict;
 use warnings;
 use Plack::Util;
+use Plack::Util::Accessor 'dir_index';
 use HTTP::Date;
 use Plack::MIME;
 use DirHandle;
@@ -67,6 +68,10 @@ sub serve_path {
 
     if ($dir_url !~ m{/$}) {
         return $self->return_dir_redirect($env);
+    }
+
+    if ($self->dir_index and -f $dir . $self->dir_index) {
+        return $self->SUPER::serve_path($env, $dir . $self->dir_index);
     }
 
     my @files = ([ "../", "Parent Directory", '', '', '' ]);

--- a/t/Plack-Middleware/directory.t
+++ b/t/Plack-Middleware/directory.t
@@ -56,4 +56,26 @@ my %test = (
 
 test_psgi %test;
 
+$handler = Plack::App::Directory->new({ root => 'share', dir_index => 'index.html' });
+
+%test = (
+    client => sub {
+        my $cb  = shift;
+
+        open my $fh, ">", "share/index.html" or die $!;
+        print $fh "<html>\n</html>";
+        close $fh;
+
+        my $res = $cb->(GET "/");
+        is $res->code, 200;
+        is $res->content, "<html>\n</html>";
+
+        unlink "share/index.html";
+
+    },
+    app => $handler,
+);
+
+test_psgi %test;
+
 done_testing;


### PR DESCRIPTION
Allows Plack::App::Directory to support index files (like `index.html`)