### PR TITLE
Bump minimum perl requirement to 5.12

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,8 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         perl-version:
-          - '5.8'
-          - '5.10'
           - '5.12'
           - '5.14'
           - '5.16'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,6 +22,9 @@ jobs:
           - '5.28'
           - '5.30'
           - '5.32'
+          - '5.34'
+          - '5.36'
+          - '5.38'
     container:
       image: perl:${{ matrix.perl-version }}
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,6 @@ jobs:
           - '5.32'
           - '5.34'
           - '5.36'
-          - '5.38'
     container:
       image: perl:${{ matrix.perl-version }}
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,6 +7,7 @@ jobs:
   perl:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         perl-version:
           - '5.8'

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.008001';
+requires 'perl', '5.012000';
 
 requires 'Cookie::Baker', '0.07';
 requires 'Devel::StackTrace', '1.23';


### PR DESCRIPTION
Some of the transient dependencies have the requirement for 5.10 and 5.12 and CI is currently failing. This PR just adds the runtime requirement of perl 5.12, without adding the explicit `use 5.012;` line so if someone wants to install and run it by hand it will work just fine.