### PR TITLE
Add web assembly MIME type

### DIFF
--- a/lib/Plack/MIME.pm
+++ b/lib/Plack/MIME.pm
@@ -156,6 +156,7 @@ our $MIME_TYPES = {
     ".vcs"     => "text/x-vcalendar",
     ".vrml"    => "model/vrml",
     ".war"     => "application/java-archive",
+    ".wasm"    => "application/wasm",
     ".wav"     => "audio/x-wav",
     ".webm"    => "video/webm",
     ".webp"    => "image/webp",

--- a/t/Plack-MIME/basic.t
+++ b/t/Plack-MIME/basic.t
@@ -8,5 +8,6 @@ is x "foo.png", "image/png";
 is x "foo.GIF", "image/gif";
 is x "foo.bar", undef;
 is x "foo.mp3", "audio/mpeg";
+is x "my.wasm", "application/wasm";
 
 done_testing;


### PR DESCRIPTION
Add support for `.wasm` (web assembly) files.

https://webassembly.github.io/spec/web-api/index.html#mediaType