### PR TITLE
Revert "perl:5.38 seems unavailable yet"

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,6 +22,7 @@ jobs:
           - '5.32'
           - '5.34'
           - '5.36'
+          - '5.38'
     container:
       image: perl:${{ matrix.perl-version }}
     steps:


### PR DESCRIPTION
This reverts commit 268b7f3ea3ed4225f3c40b11948d8cd0d27da8ee.

Currently, 5.38 is available. 