### PR TITLE
Add `auth-basic.psgi` example

### DIFF
--- a/eg/dot-psgi/auth-basic.psgi
+++ b/eg/dot-psgi/auth-basic.psgi
@@ -1,0 +1,25 @@
+use v5.38;
+
+use Plack::Builder;
+use Authen::Simple::Passwd;
+use Log::Log4perl; # For additional logging from Authen::Simple::Passwd
+
+Log::Log4perl -> easy_init();
+
+builder {
+
+  enable 'Auth::Basic' ,
+    realm         => 'My Plack Perl Web Server' ,
+    authenticator => Authen::Simple::Passwd -> new(
+      path => "$ENV{HOME}/.htpasswd" , # File: <user>:<password>
+      log  => Log::Log4perl -> get_logger( 'Authen::Simple::Passwd' ) ,
+    );
+
+  sub {
+    return [ 200 ,
+      [ 'Content-Type' => 'text/plain' ] ,
+      [ 'Some text' . rand ]
+    ];
+  }
+
+};


### PR DESCRIPTION
This illustrates the point referenced in Plack's [`Auth::Basic`][1] middleware:

Using [`Authen::Simple::Passwd`][2] (file) to authenticate against

[1]: https://metacpan.org/pod/Plack::Middleware::Auth::Basic#authenticator
[2]: https://metacpan.org/pod/Authen::Simple::Passwd