### PR TITLE
Add previously unused UA timeout to User Agent in HTTP::Server::PSGI test

### DIFF
--- a/t/HTTP-Server-PSGI/listen.t
+++ b/t/HTTP-Server-PSGI/listen.t
@@ -29,6 +29,7 @@ test_tcp(
     client => sub {
         my $port = shift;
         my $ua = LWP::UserAgent->new;
+		$ua->timeout($ua_timeout);
         my $res = $ua->get("http://127.0.0.1:$port/");
         ok $res->is_success;
         is $res->code, 200;


### PR DESCRIPTION
While hacking on Plack we noticed this timeout is instantiated but never used, thanks.