### PR TITLE
Add perl:5.40

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,6 +23,7 @@ jobs:
           - '5.34'
           - '5.36'
           - '5.38'
+          - '5.40'
     container:
       image: perl:${{ matrix.perl-version }}
     steps:


### PR DESCRIPTION
Perl 5.40 has been released. It is also available as a Docker image.

https://github.com/perl/docker-perl/blob/310b7bc1e03fa38094922c1a2e2cbd608bd0b3a4/5.040.000-main-bookworm/Dockerfile
