### PR TITLE
Avoid try block just for checking $object->isa

### DIFF
--- a/lib/HTTP/Message/PSGI.pm
+++ b/lib/HTTP/Message/PSGI.pm
@@ -8,7 +8,7 @@ use Carp ();
 use HTTP::Status qw(status_message);
 use URI::Escape ();
 use Plack::Util;
-use Try::Tiny;
+use Scalar::Util ();
 
 my $TRUE  = (1 == 1);
 my $FALSE = !$TRUE;
@@ -16,9 +16,8 @@ my $FALSE = !$TRUE;
 sub req_to_psgi {
     my $req = shift;
 
-    unless (try { $req->isa('HTTP::Request') }) {
-        Carp::croak("Request is not HTTP::Request: $req");
-    }
+    Carp::croak("Request is not HTTP::Request: $req")
+        unless Scalar::Util::blessed $req && $req->isa('HTTP::Request');
 
     # from HTTP::Request::AsCGI
     my $host = $req->header('Host');


### PR DESCRIPTION
This is a straightforward change to avoid using `try { $object->isa(...) }`. There are two other `isa` calls in code and they also use `blessed` and not `try`, so this makes the code base more consistent.