### PR TITLE
quality of life: 0 -> 0.0.0.0

### DIFF
--- a/lib/Plack/Runner.pm
+++ b/lib/Plack/Runner.pm
@@ -209,7 +209,7 @@ sub prepare_devel {
     push @{$self->{options}}, server_ready => sub {
         my($args) = @_;
         my $name  = $args->{server_software} || ref($args); # $args is $server
-        my $host  = $args->{host} || 0;
+        my $host  = $args->{host} || '0.0.0.0';
         my $proto = $args->{proto} || 'http';
         print STDERR "$name: Accepting connections at $proto://$host:$args->{port}/\n";
     };


### PR DESCRIPTION
In most terminals you can Ctrl+Mouse1 valid HTTP urls, `http://0:<PORT>` is not clickable in most terminals, `http://0.0.0.0:<PORT>` is, this is a nice little quality of life change, so I don't have to type "`http://0.0.0.0:<PORT>`" in development.

Thanks :)