### PR TITLE
Enable custom PSGI variables to be used for testing

### DIFF
--- a/lib/Plack/Test.pm
+++ b/lib/Plack/Test.pm
@@ -100,7 +100,7 @@ to be a valid PSGI application code reference.
 
 =item request
 
-  $res = $test->request($request);
+  $res = $test->request($request, %options);
 
 takes an HTTP::Request object, runs it through the PSGI application to
 test and returns an HTTP::Response object.
@@ -164,6 +164,9 @@ The available values for the backend are:
 
 (Default) Creates a PSGI env hash out of HTTP::Request object, runs
 the PSGI application in-process and returns HTTP::Response.
+
+Custom PSGI environment variables can be passed using %options of the request()
+method.
 
 =item Server
 

--- a/lib/Plack/Test/MockHTTP.pm
+++ b/lib/Plack/Test/MockHTTP.pm
@@ -14,11 +14,11 @@ sub new {
 }
 
 sub request {
-    my($self, $req) = @_;
+    my($self, $req) = (shift, shift);
 
     $req->uri->scheme('http')    unless defined $req->uri->scheme;
     $req->uri->host('localhost') unless defined $req->uri->host;
-    my $env = $req->to_psgi;
+    my $env = $req->to_psgi(@_);
 
     my $res = try {
         HTTP::Response->from_psgi($self->{app}->($env));


### PR DESCRIPTION
This commit enables custom PSGI environment variables to be used during testing. For example, REMOTE_ADDR could be used to simulate an IP address for the client.