### PR TITLE
Fix Lint: allow lowercase and special chars in REQUEST_METHOD

### DIFF
--- a/lib/Plack/Middleware/Lint.pm
+++ b/lib/Plack/Middleware/Lint.pm
@@ -30,7 +30,7 @@ sub validate_env {
     unless ($env->{REQUEST_METHOD}) {
         die('Missing env param: REQUEST_METHOD');
     }
-    unless ($env->{REQUEST_METHOD} =~ /^[A-Z]+$/) {
+    unless ($env->{REQUEST_METHOD} =~ /^[A-Za-z0-9!#\$%&'*+\-.^_`|~]+$/) {
         die("Invalid env param: REQUEST_METHOD($env->{REQUEST_METHOD})");
     }
     unless (defined($env->{SCRIPT_NAME})) { # allows empty string

--- a/t/Plack-Middleware/lint_env.t
+++ b/t/Plack-Middleware/lint_env.t
@@ -13,11 +13,15 @@ $app = Plack::Middleware::Lint->wrap($app);
 
 my @good_env = (
     { PATH_INFO => '' },
+    { REQUEST_METHOD => 'get' },
+    { REQUEST_METHOD => 'GeT' },
+    { REQUEST_METHOD => 'my-custom-method' },
 );
 
 my @bad_env = (
     [ { REQUEST_METHOD => undef }, qr/Missing env param: REQUEST_METHOD/ ],
-    [ { REQUEST_METHOD => "foo" },, qr/Invalid env param: REQUEST_METHOD/ ],
+    [ { REQUEST_METHOD => "foo bar" }, qr/Invalid env param: REQUEST_METHOD/ ],
+    [ { REQUEST_METHOD => "" }, qr/Missing env param: REQUEST_METHOD/ ],
     [ { PATH_INFO => 'foo' }, qr/PATH_INFO must begin with \// ],
     [ { SERVER_PORT => undef }, qr/Missing mandatory .*SERVER_PORT/ ],
     [ { SERVER_PROTOCOL => 'HTTP/x' }, qr/Invalid SERVER_PROTOCOL/ ],


### PR DESCRIPTION
## Summary
- Updated the `REQUEST_METHOD` validation regex from `/^[A-Z]+$/` to RFC 9110 tchar to accept lowercase methods, digits, and other valid token characters
- The previous check was over-restrictive: RFC 9110 Section 9.1 defines method as a token, which permits characters beyond uppercase ASCII letters

Fixes #588

## Test plan
- [ ] `prove -Ilib t/Plack-Middleware/lint_env.t` passes (12/12 tests)
- [ ] Tests cover lowercase (`get`), mixed case (`myMethod`), hyphenated (`X-Custom`), and empty string (rejected)